### PR TITLE
feat: project scaffolding and foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# ── Scan API (API key or bearer token auth) ──────────────────────────
+PANW_AI_SEC_API_KEY=
+PANW_AI_SEC_API_TOKEN=
+PANW_AI_SEC_PROFILE_NAME=
+# PANW_AI_SEC_API_ENDPOINT=https://service.api.aisecurity.paloaltonetworks.com
+
+# ── Management API (OAuth2 client credentials) ──────────────────────
+PANW_MGMT_CLIENT_ID=
+PANW_MGMT_CLIENT_SECRET=
+PANW_MGMT_TSG_ID=
+# PANW_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/aisec
+# PANW_MGMT_TOKEN_ENDPOINT=https://auth.apps.paloaltonetworks.com/oauth2/access_token
+
+# ── Model Security API (falls back to PANW_MGMT_* vars above) ──────
+# PANW_MODEL_SEC_CLIENT_ID=
+# PANW_MODEL_SEC_CLIENT_SECRET=
+# PANW_MODEL_SEC_TSG_ID=
+# PANW_MODEL_SEC_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/data
+# PANW_MODEL_SEC_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/aims/mgmt
+
+# ── Red Team API (falls back to PANW_MGMT_* vars above) ────────────
+# PANW_RED_TEAM_CLIENT_ID=
+# PANW_RED_TEAM_CLIENT_SECRET=
+# PANW_RED_TEAM_TSG_ID=
+# PANW_RED_TEAM_DATA_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/data-plane
+# PANW_RED_TEAM_MGMT_ENDPOINT=https://api.sase.paloaltonetworks.com/ai-red-teaming/mgmt-plane

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Coverage
+coverage/
+*.out
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE / Editor settings
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# MkDocs build output
+site/
+
+# Review documents
+REVIEW-*.md
+
+# Vendor (optional — we use Go modules)
+# vendor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Go SDK for Palo Alto Networks Prisma AIRS — covers the full lifecycle across all four service domains (AI Runtime Security, Model Security, AI Red Teaming) plus configuration management. Port of the TypeScript `@cdot65/prisma-airs-sdk`. Zero external dependencies (stdlib only).
+
+## Commands
+
+```bash
+make fmt            # gofmt -s -w
+make vet            # go vet ./...
+make lint           # golangci-lint run
+make test           # go test -race ./...
+make test-coverage  # go test -race -coverprofile=coverage.out ./...
+make build          # go build ./...
+make check          # fmt + vet + lint + test (CI equivalent)
+```
+
+Run a single test file:
+
+```bash
+go test -v ./aisec/scan/ -run TestSyncScan
+```
+
+Run a single test by name:
+
+```bash
+go test -v ./... -run "TestName"
+```
+
+## Architecture
+
+**4 service domains**, 2 auth methods:
+
+- **Scan API** (API Key): `NewScanner()` → `SyncScan()` → AIRS content scanning endpoint
+- **Management API** (OAuth2): `NewManagementClient()` → profiles/topics CRUD
+- **Model Security API** (OAuth2): `NewModelSecurityClient()` → model scans, security groups, rules
+- **Red Team API** (OAuth2): `NewRedTeamClient()` → scans, reports, targets, custom attacks
+
+Key packages:
+
+- `aisec/scan/` — Scanner, Content (API key auth)
+- `aisec/management/` — ManagementClient + 8 sub-clients (profiles, topics, apikeys, apps, dlp, deployment, scanlogs, oauth)
+- `aisec/modelsecurity/` — ModelSecurityClient + 3 sub-clients (scans, groups, rules)
+- `aisec/redteam/` — RedTeamClient + 5 sub-clients (scans, reports, customAttackReports, targets, customAttacks)
+- `aisec/internal/` — HTTP client, retry with exponential backoff, OAuth client
+- `aisec/` — constants, configuration, errors, utils, models
+
+**Auth:** API key (HMAC-SHA256) for AIRS scans. OAuth2 client_credentials for everything else.
+
+**Validation:** Content validates at setter time, Scanner validates arguments. Models use struct tags for JSON marshaling.
+
+## Conventions
+
+- Go 1.22+ minimum, stdlib-only (no external deps)
+- `context.Context` as first param on all API methods
+- Errors wrapped with `fmt.Errorf("...: %w", err)` for unwrapping
+- Custom error type: `AISecSDKError` with `ErrorType` enum
+- Tests in `_test.go` files alongside source, use `httptest.NewServer` for mocking
+- Exported API surface from `aisec/` package root
+- Batch operations limited to 5 items max
+- Package names: lowercase, no underscores
+
+## CI/CD
+
+- GitHub Actions test matrix: Go 1.22, 1.23, 1.24
+- golangci-lint for linting
+- MkDocs Material for documentation, deployed to GitHub Pages

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Calvin Remsburg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: fmt vet lint test test-coverage build check clean
+
+## Format source code
+fmt:
+	gofmt -s -w .
+
+## Run go vet
+vet:
+	go vet ./...
+
+## Run golangci-lint
+lint:
+	golangci-lint run ./...
+
+## Run tests with race detector
+test:
+	go test -race ./...
+
+## Run tests with coverage
+test-coverage:
+	go test -race -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
+## Build all packages
+build:
+	go build ./...
+
+## Run all checks (CI equivalent)
+check: fmt vet lint test
+
+## Remove build artifacts
+clean:
+	rm -f coverage.out
+	rm -rf site/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,158 @@
+# prisma-airs-go
+
+[![CI](https://github.com/cdot65/prisma-airs-go/actions/workflows/ci.yml/badge.svg)](https://github.com/cdot65/prisma-airs-go/actions/workflows/ci.yml)
+[![Tests](https://github.com/cdot65/prisma-airs-go/actions/workflows/test.yml/badge.svg)](https://github.com/cdot65/prisma-airs-go/actions/workflows/test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/cdot65/prisma-airs-go.svg)](https://pkg.go.dev/github.com/cdot65/prisma-airs-go)
+[![Go 1.22+](https://img.shields.io/badge/go-%3E%3D1.22-00ADD8)](https://go.dev/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+Go SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all three service domains: **AI Runtime Security**, **AI Red Teaming**, and **Model Security**.
+
+## Installation
+
+```bash
+go get github.com/cdot65/prisma-airs-go
+```
+
+Requires Go 1.22+. Zero external dependencies (stdlib only).
+
+## What's Included
+
+| Service                 | Client                  | Auth    | Capabilities                                               |
+| ----------------------- | ----------------------- | ------- | ---------------------------------------------------------- |
+| **AI Runtime Security** | `scan.Scanner`          | API Key | Sync/async content scanning, prompt injection detection    |
+| **Management**          | `management.Client`     | OAuth2  | Profiles, topics, API keys, apps, DLP, deployment, logs    |
+| **Model Security**      | `modelsecurity.Client`  | OAuth2  | ML model scanning, security groups, rule management        |
+| **AI Red Teaming**      | `redteam.Client`        | OAuth2  | Automated red team scans, reports, targets, custom attacks |
+
+All OAuth2 services share credentials and handle token lifecycle automatically (caching, proactive refresh, 401/403 auto-retry).
+
+## Quick Start
+
+### AI Runtime Security — Content Scanning (API Key)
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/cdot65/prisma-airs-go/aisec"
+    "github.com/cdot65/prisma-airs-go/aisec/scan"
+)
+
+func main() {
+    cfg := aisec.NewConfig(aisec.WithAPIKey("YOUR_API_KEY"))
+    scanner := scan.NewScanner(cfg)
+
+    content := scan.NewContent(scan.ContentOpts{
+        Prompt:   "What is the capital of France?",
+        Response: "The capital of France is Paris.",
+    })
+
+    result, err := scanner.SyncScan(context.Background(), scan.AiProfile{ProfileName: "my-profile"}, content)
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println(result.Category) // "benign" | "malicious"
+    fmt.Println(result.Action)   // "allow" | "block"
+}
+```
+
+### Management — Configuration CRUD (OAuth2)
+
+```go
+import "github.com/cdot65/prisma-airs-go/aisec/management"
+
+client := management.NewClient(management.Opts{}) // reads PANW_MGMT_* env vars
+
+// 8 sub-clients available:
+client.Profiles      // AI security profile CRUD
+client.Topics        // Custom detection topic CRUD
+client.ApiKeys       // API key lifecycle (create, list, regenerate, delete)
+client.CustomerApps  // Customer application management
+client.DlpProfiles   // DLP data profile listing
+client.DeploymentProfiles // Deployment profile listing
+client.ScanLogs      // Scan activity log queries
+client.OAuth         // OAuth token management (get/invalidate)
+```
+
+### Model Security — ML Model Scanning (OAuth2)
+
+```go
+import "github.com/cdot65/prisma-airs-go/aisec/modelsecurity"
+
+client := modelsecurity.NewClient(modelsecurity.Opts{}) // falls back to PANW_MGMT_* env vars
+
+// 3 sub-clients: Scans, SecurityGroups, SecurityRules
+scans, _ := client.Scans.List(ctx, modelsecurity.ScanListOpts{Limit: 10})
+groups, _ := client.SecurityGroups.List(ctx, modelsecurity.GroupListOpts{})
+rules, _ := client.SecurityRules.List(ctx, modelsecurity.RuleListOpts{})
+```
+
+### AI Red Teaming — Automated Testing (OAuth2)
+
+```go
+import "github.com/cdot65/prisma-airs-go/aisec/redteam"
+
+client := redteam.NewClient(redteam.Opts{}) // falls back to PANW_MGMT_* env vars
+
+// 5 sub-clients: Scans, Reports, CustomAttackReports, Targets, CustomAttacks
+scans, _ := client.Scans.List(ctx, redteam.ScanListOpts{Limit: 5})
+targets, _ := client.Targets.List(ctx, redteam.TargetListOpts{})
+categories, _ := client.Scans.GetCategories(ctx)
+```
+
+## Authentication
+
+| Auth Method                     | Used By                                                     |
+| ------------------------------- | ----------------------------------------------------------- |
+| **API Key** (HMAC-SHA256)       | AI Runtime Security scans only                              |
+| **OAuth2** (client_credentials) | Everything else — Management CRUD, Red Team, Model Security |
+
+```bash
+# AI Runtime Security scans
+export PANW_AI_SEC_API_KEY=your-api-key
+
+# OAuth2 (shared by Management, Red Team, Model Security)
+export PANW_MGMT_CLIENT_ID=your-client-id
+export PANW_MGMT_CLIENT_SECRET=your-client-secret
+export PANW_MGMT_TSG_ID=1234567890
+```
+
+## Error Handling
+
+```go
+import "github.com/cdot65/prisma-airs-go/aisec"
+
+result, err := scanner.SyncScan(ctx, profile, content)
+if err != nil {
+    var sdkErr *aisec.AISecSDKError
+    if errors.As(err, &sdkErr) {
+        fmt.Println(sdkErr.ErrorType) // aisec.ServerSideError, etc.
+        fmt.Println(sdkErr.Message)
+    }
+}
+```
+
+Error types: `ServerSideError`, `ClientSideError`, `UserRequestPayloadError`, `MissingVariableError`, `AISecSDKInternalError`, `OAuthError`.
+
+## Documentation
+
+Full documentation at **[cdot65.github.io/prisma-airs-go](https://cdot65.github.io/prisma-airs-go/)** — includes API reference, service guides, OAuth lifecycle docs, and examples.
+
+## Development
+
+```bash
+make build          # go build ./...
+make test           # go test -race ./...
+make test-coverage  # go test with coverage report
+make lint           # golangci-lint
+make check          # fmt + vet + lint + test
+```
+
+## License
+
+MIT

--- a/aisec/doc.go
+++ b/aisec/doc.go
@@ -1,0 +1,27 @@
+// Package aisec provides a Go SDK for Palo Alto Networks Prisma AI Runtime Security (AIRS).
+//
+// The SDK covers four service domains:
+//
+//   - Scan API (API key auth): real-time content scanning
+//   - Management API (OAuth2): security profile and topic CRUD
+//   - Model Security API (OAuth2): ML model scanning and security rules
+//   - Red Team API (OAuth2): automated attack testing and reporting
+//
+// # Quick Start
+//
+// Scan API with API key:
+//
+//	import "github.com/cdot65/prisma-airs-go/aisec"
+//
+//	cfg := aisec.NewConfig(aisec.WithAPIKey("your-api-key"))
+//	scanner := aisec.NewScanner(cfg)
+//	resp, err := scanner.SyncScan(ctx, profile, content)
+//
+// Management API with OAuth2:
+//
+//	client := aisec.NewManagementClient(aisec.ManagementOpts{
+//	    ClientID:     "id",
+//	    ClientSecret: "secret",
+//	    TsgID:        "tsg-id",
+//	})
+package aisec

--- a/aisec/internal/doc.go
+++ b/aisec/internal/doc.go
@@ -1,0 +1,4 @@
+// Package internal contains shared HTTP client, retry logic, and OAuth infrastructure.
+//
+// This package is not part of the public API and should not be imported directly.
+package internal

--- a/aisec/management/doc.go
+++ b/aisec/management/doc.go
@@ -1,0 +1,6 @@
+// Package management provides the Management API client for AIRS configuration.
+//
+// The ManagementClient uses OAuth2 client_credentials and exposes sub-clients for:
+// profiles, topics, API keys, customer apps, DLP profiles, deployment profiles,
+// scan logs, and OAuth token management.
+package management

--- a/aisec/modelsecurity/doc.go
+++ b/aisec/modelsecurity/doc.go
@@ -1,0 +1,5 @@
+// Package modelsecurity provides the Model Security API client for ML model scanning.
+//
+// The ModelSecurityClient uses OAuth2 and exposes sub-clients for:
+// scans (data plane), security groups and security rules (management plane).
+package modelsecurity

--- a/aisec/redteam/doc.go
+++ b/aisec/redteam/doc.go
@@ -1,0 +1,7 @@
+// Package redteam provides the Red Team API client for automated attack testing.
+//
+// The RedTeamClient uses OAuth2 and exposes sub-clients for:
+// scans, reports, custom attack reports (data plane), and targets,
+// custom attacks (management plane), plus convenience methods for
+// statistics, quotas, and dashboards.
+package redteam

--- a/aisec/scan/doc.go
+++ b/aisec/scan/doc.go
@@ -1,0 +1,5 @@
+// Package scan provides the Scan API client for AI Runtime Security content scanning.
+//
+// The Scanner supports synchronous scans, asynchronous batch scans, and result queries.
+// Authentication uses API key with HMAC-SHA256 payload signing.
+package scan

--- a/examples/basic-scan/main.go
+++ b/examples/basic-scan/main.go
@@ -1,0 +1,8 @@
+// Example: basic synchronous content scan using API key auth.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("TODO: implement basic scan example")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cdot65/prisma-airs-go
+
+go 1.22


### PR DESCRIPTION
## Summary
- Go module init (`github.com/cdot65/prisma-airs-go`, Go 1.22+)
- `.gitignore`, `.env.example` (all PANW_* env vars)
- `CLAUDE.md` with project conventions
- `README.md` with badges, feature table, quick start, auth docs
- `Makefile` with fmt/vet/lint/test/build/check targets
- `LICENSE` (MIT)
- Package structure: `aisec/`, `aisec/scan/`, `aisec/management/`, `aisec/modelsecurity/`, `aisec/redteam/`, `aisec/internal/`
- Doc comments on all packages
- Example placeholder (`examples/basic-scan/`)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

Closes #1