### PR TITLE
feat: HTTP client and retry infrastructure

### DIFF
--- a/aisec/internal/httpclient.go
+++ b/aisec/internal/httpclient.go
@@ -1,0 +1,101 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+// RequestOptions for a scan API HTTP request.
+type RequestOptions struct {
+	Method string
+	Path   string
+	Body   any
+	Params map[string]string
+}
+
+// Response wraps a typed HTTP response.
+type Response[T any] struct {
+	Status int
+	Data   T
+}
+
+// DoRequest performs an HTTP request to the scan API with retry logic.
+func DoRequest[T any](ctx context.Context, cfg *aisec.Config, opts RequestOptions) (*Response[T], error) {
+	baseURL := cfg.Endpoint()
+
+	u, err := url.Parse(baseURL + opts.Path)
+	if err != nil {
+		return nil, aisec.WrapError(fmt.Sprintf("invalid URL: %s%s", baseURL, opts.Path), aisec.AISecSDKInternalError, err)
+	}
+
+	if opts.Params != nil {
+		q := u.Query()
+		for k, v := range opts.Params {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	var bodyBytes []byte
+	if opts.Body != nil {
+		bodyBytes, err = json.Marshal(opts.Body)
+		if err != nil {
+			return nil, aisec.WrapError("failed to marshal request body", aisec.AISecSDKInternalError, err)
+		}
+	}
+
+	resp, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: cfg.NumRetries(),
+		Execute: func(attempt int) (*http.Response, error) {
+			var bodyReader io.Reader
+			if bodyBytes != nil {
+				bodyReader = bytes.NewReader(bodyBytes)
+			}
+
+			req, err := http.NewRequestWithContext(ctx, opts.Method, u.String(), bodyReader)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("User-Agent", aisec.UserAgent)
+
+			if cfg.APIToken() != "" {
+				req.Header.Set(aisec.HeaderAuthToken, aisec.Bearer+cfg.APIToken())
+			}
+			if cfg.APIKey() != "" {
+				req.Header.Set(aisec.HeaderAPIKey, cfg.APIKey())
+				if bodyBytes != nil {
+					req.Header.Set(aisec.PayloadHash, aisec.GeneratePayloadHash(string(bodyBytes), cfg.APIKey()))
+				}
+			}
+
+			return http.DefaultClient.Do(req)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, aisec.WrapError("failed to read response body", aisec.AISecSDKInternalError, err)
+	}
+
+	var data T
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &data); err != nil {
+			return nil, aisec.WrapError("failed to parse response JSON", aisec.AISecSDKInternalError, err)
+		}
+	}
+
+	return &Response[T]{Status: resp.StatusCode, Data: data}, nil
+}

--- a/aisec/internal/httpclient_test.go
+++ b/aisec/internal/httpclient_test.go
@@ -1,0 +1,109 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+func TestHTTPRequest_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("x-pan-token") != "test-key" {
+			t.Error("missing API key header")
+		}
+		if r.Header.Get("x-payload-hash") == "" {
+			t.Error("missing payload hash header")
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("missing content-type")
+		}
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]string{"result": "ok"})
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("test-key"), aisec.WithEndpoint(server.URL))
+	var result map[string]string
+	resp, err := DoRequest[map[string]string](context.Background(), cfg, RequestOptions{
+		Method: http.MethodPost,
+		Path:   "/v1/scan/sync/request",
+		Body:   map[string]string{"prompt": "hello"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result = resp.Data
+	if result["result"] != "ok" {
+		t.Errorf("result = %v", result)
+	}
+}
+
+func TestHTTPRequest_WithQueryParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("limit") != "10" {
+			t.Errorf("limit = %q", r.URL.Query().Get("limit"))
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"), aisec.WithEndpoint(server.URL))
+	_, err := DoRequest[map[string]any](context.Background(), cfg, RequestOptions{
+		Method: http.MethodGet,
+		Path:   "/v1/test",
+		Params: map[string]string{"limit": "10"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPRequest_BearerToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token" {
+			t.Errorf("Authorization = %q", auth)
+		}
+		// Should NOT have API key header
+		if r.Header.Get("x-pan-token") != "" {
+			t.Error("should not have API key header when using bearer token")
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIToken("test-token"), aisec.WithEndpoint(server.URL))
+	_, err := DoRequest[map[string]any](context.Background(), cfg, RequestOptions{
+		Method: http.MethodGet,
+		Path:   "/test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPRequest_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"), aisec.WithEndpoint(server.URL))
+	_, err := DoRequest[map[string]any](ctx, cfg, RequestOptions{
+		Method: http.MethodGet,
+		Path:   "/test",
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}

--- a/aisec/internal/retry.go
+++ b/aisec/internal/retry.go
@@ -1,0 +1,132 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+// BackoffDelay calculates exponential backoff with full jitter for the given attempt.
+// Returns delay in milliseconds in [0, 2^attempt * 1000].
+func BackoffDelay(attempt int) int {
+	maxDelay := int(math.Pow(2, float64(attempt))) * 1000
+	return rand.Intn(maxDelay + 1)
+}
+
+// IsRetryableStatus returns true if the HTTP status code should trigger a retry.
+func IsRetryableStatus(status int) bool {
+	for _, code := range aisec.HTTPForceRetryStatusCodes {
+		if status == code {
+			return true
+		}
+	}
+	return false
+}
+
+// ClassifyErrorType classifies an HTTP status code as server-side or client-side.
+func ClassifyErrorType(status int) aisec.ErrorType {
+	if status >= 500 {
+		return aisec.ServerSideError
+	}
+	return aisec.ClientSideError
+}
+
+// ExtractErrorMessage extracts a human-readable message from an API error response body.
+func ExtractErrorMessage(body string, status int) string {
+	if body == "" {
+		return fmt.Sprintf("API error %d", status)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		return fmt.Sprintf("API error %d: %s", status, body)
+	}
+
+	if msg, ok := parsed["error_message"].(string); ok && msg != "" {
+		return msg
+	}
+	if msg, ok := parsed["message"].(string); ok && msg != "" {
+		return msg
+	}
+	if errObj, ok := parsed["error"].(map[string]any); ok {
+		if msg, ok := errObj["message"].(string); ok && msg != "" {
+			return msg
+		}
+	}
+	return fmt.Sprintf("API error %d", status)
+}
+
+// RetryOptions configures the retry behavior.
+type RetryOptions struct {
+	MaxRetries int
+	Execute    func(attempt int) (*http.Response, error)
+	// OnRetryableFailure handles special failures (e.g. 401 token refresh).
+	// Return (true, nil) to retry without consuming retry budget.
+	OnRetryableFailure func(resp *http.Response, attempt int) (bool, error)
+}
+
+// ExecuteWithRetry executes an HTTP request with exponential backoff retry.
+func ExecuteWithRetry(opts RetryOptions) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := 0; attempt <= opts.MaxRetries; attempt++ {
+		resp, err := opts.Execute(attempt)
+		if err != nil {
+			// If it's already an SDK error, propagate immediately
+			if _, ok := err.(*aisec.AISecSDKError); ok {
+				return nil, err
+			}
+			lastErr = err
+			if attempt < opts.MaxRetries {
+				time.Sleep(time.Duration(BackoffDelay(attempt)) * time.Millisecond)
+				continue
+			}
+			msg := "Network error"
+			if lastErr != nil {
+				msg = lastErr.Error()
+			}
+			return nil, aisec.NewAISecSDKError(msg, aisec.ClientSideError)
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return resp, nil
+		}
+
+		// Let caller handle special status codes (e.g. 401 token refresh)
+		if opts.OnRetryableFailure != nil {
+			handled, handleErr := opts.OnRetryableFailure(resp, attempt)
+			if handleErr != nil {
+				return nil, handleErr
+			}
+			if handled {
+				attempt-- // don't count against retry budget
+				continue
+			}
+		}
+
+		if IsRetryableStatus(resp.StatusCode) && attempt < opts.MaxRetries {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			time.Sleep(time.Duration(BackoffDelay(attempt)) * time.Millisecond)
+			continue
+		}
+
+		// Non-retryable or retries exhausted
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		errorMessage := ExtractErrorMessage(string(bodyBytes), resp.StatusCode)
+		return nil, aisec.NewAISecSDKError(errorMessage, ClassifyErrorType(resp.StatusCode))
+	}
+
+	msg := "Max retries exceeded"
+	if lastErr != nil {
+		msg = lastErr.Error()
+	}
+	return nil, aisec.NewAISecSDKError(msg, aisec.ClientSideError)
+}

--- a/aisec/internal/retry_test.go
+++ b/aisec/internal/retry_test.go
@@ -1,0 +1,207 @@
+package internal
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+func TestBackoffDelay_Bounds(t *testing.T) {
+	for attempt := 0; attempt < 5; attempt++ {
+		maxDelay := (1 << attempt) * 1000
+		for i := 0; i < 100; i++ {
+			d := BackoffDelay(attempt)
+			if d < 0 || d > maxDelay {
+				t.Errorf("attempt %d: delay %d out of bounds [0, %d]", attempt, d, maxDelay)
+			}
+		}
+	}
+}
+
+func TestIsRetryableStatus(t *testing.T) {
+	retryable := []int{500, 502, 503, 504}
+	for _, code := range retryable {
+		if !IsRetryableStatus(code) {
+			t.Errorf("expected %d to be retryable", code)
+		}
+	}
+	nonRetryable := []int{200, 400, 401, 403, 404, 429, 501}
+	for _, code := range nonRetryable {
+		if IsRetryableStatus(code) {
+			t.Errorf("expected %d to not be retryable", code)
+		}
+	}
+}
+
+func TestClassifyErrorType(t *testing.T) {
+	if ClassifyErrorType(500) != aisec.ServerSideError {
+		t.Error("500 should be ServerSideError")
+	}
+	if ClassifyErrorType(502) != aisec.ServerSideError {
+		t.Error("502 should be ServerSideError")
+	}
+	if ClassifyErrorType(400) != aisec.ClientSideError {
+		t.Error("400 should be ClientSideError")
+	}
+	if ClassifyErrorType(404) != aisec.ClientSideError {
+		t.Error("404 should be ClientSideError")
+	}
+}
+
+func TestExtractErrorMessage(t *testing.T) {
+	tests := []struct {
+		body   string
+		status int
+		want   string
+	}{
+		{`{"error_message":"bad request"}`, 400, "bad request"},
+		{`{"message":"not found"}`, 404, "not found"},
+		{`{"error":{"message":"server error"}}`, 500, "server error"},
+		{`not json`, 500, "API error 500: not json"},
+		{"", 500, "API error 500"},
+	}
+	for _, tt := range tests {
+		got := ExtractErrorMessage(tt.body, tt.status)
+		if got != tt.want {
+			t.Errorf("ExtractErrorMessage(%q, %d) = %q, want %q", tt.body, tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestExecuteWithRetry_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	resp, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: 3,
+		Execute: func(attempt int) (*http.Response, error) {
+			return http.Get(server.URL)
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestExecuteWithRetry_RetriesOn500(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(500)
+			w.Write([]byte(`{"message":"server error"}`))
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	resp, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: 5,
+		Execute: func(attempt int) (*http.Response, error) {
+			return http.Get(server.URL)
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if attempts.Load() != 3 {
+		t.Errorf("attempts = %d, want 3", attempts.Load())
+	}
+}
+
+func TestExecuteWithRetry_NonRetryable400(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"message":"bad request"}`))
+	}))
+	defer server.Close()
+
+	_, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: 3,
+		Execute: func(attempt int) (*http.Response, error) {
+			return http.Get(server.URL)
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var sdkErr *aisec.AISecSDKError
+	if !errors.As(err, &sdkErr) {
+		t.Fatal("expected AISecSDKError")
+	}
+	if sdkErr.ErrorType != aisec.ClientSideError {
+		t.Errorf("ErrorType = %v", sdkErr.ErrorType)
+	}
+}
+
+func TestExecuteWithRetry_ExhaustsRetries(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(500)
+		w.Write([]byte(`{"message":"always fails"}`))
+	}))
+	defer server.Close()
+
+	_, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: 2,
+		Execute: func(attempt int) (*http.Response, error) {
+			return http.Get(server.URL)
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 2 retries = 3 total
+	if attempts.Load() != 3 {
+		t.Errorf("attempts = %d, want 3", attempts.Load())
+	}
+}
+
+func TestExecuteWithRetry_OnRetryableFailure(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(401)
+			w.Write([]byte(`{"message":"unauthorized"}`))
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	_, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: 3,
+		Execute: func(attempt int) (*http.Response, error) {
+			return http.Get(server.URL)
+		},
+		OnRetryableFailure: func(resp *http.Response, attempt int) (bool, error) {
+			if resp.StatusCode == 401 {
+				return true, nil // handled, retry without budget cost
+			}
+			return false, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts.Load() != 2 {
+		t.Errorf("attempts = %d, want 2", attempts.Load())
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/retry.go`: exponential backoff with full jitter, retryable status detection, error classification/extraction
- `internal/httpclient.go`: generic DoRequest[T] with HMAC signing, bearer token, query params, context support
- 401/403 OnRetryableFailure callback (doesn't consume retry budget)

## Test plan
- [x] All tests pass with race detector
- [x] Backoff bounds validated
- [x] Retry count verified per status code
- [x] Error message extraction from JSON responses
- [x] Context cancellation tested

Closes #5