### PR TITLE
feat: Scan API — Scanner, Content, models

### DIFF
--- a/aisec/scan/content.go
+++ b/aisec/scan/content.go
@@ -1,0 +1,132 @@
+package scan
+
+import (
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+// ContentOpts are options for creating a Content instance.
+type ContentOpts struct {
+	Prompt       string
+	Response     string
+	Context      string
+	CodePrompt   string
+	CodeResponse string
+	ToolEvent    *ToolEvent
+}
+
+// Content represents content to be scanned by AIRS.
+// Validates byte-length limits on construction.
+type Content struct {
+	prompt       string
+	response     string
+	context      string
+	codePrompt   string
+	codeResponse string
+	toolEvent    *ToolEvent
+}
+
+// NewContent creates a new Content with byte-length validation.
+func NewContent(opts ContentOpts) (*Content, error) {
+	if opts.Prompt == "" && opts.Response == "" && opts.CodePrompt == "" &&
+		opts.CodeResponse == "" && opts.ToolEvent == nil {
+		return nil, aisec.NewAISecSDKError(
+			"at least one of Prompt, Response, CodePrompt, CodeResponse, or ToolEvent must be provided",
+			aisec.UserRequestPayloadError,
+		)
+	}
+
+	c := &Content{}
+
+	if opts.Prompt != "" {
+		if len(opts.Prompt) > aisec.MaxContentPromptLength {
+			return nil, aisec.NewAISecSDKError("prompt exceeds max length", aisec.UserRequestPayloadError)
+		}
+		c.prompt = opts.Prompt
+	}
+	if opts.Response != "" {
+		if len(opts.Response) > aisec.MaxContentResponseLength {
+			return nil, aisec.NewAISecSDKError("response exceeds max length", aisec.UserRequestPayloadError)
+		}
+		c.response = opts.Response
+	}
+	if opts.Context != "" {
+		if len(opts.Context) > aisec.MaxContentContextLength {
+			return nil, aisec.NewAISecSDKError("context exceeds max length", aisec.UserRequestPayloadError)
+		}
+		c.context = opts.Context
+	}
+	if opts.CodePrompt != "" {
+		if len(opts.CodePrompt) > aisec.MaxContentPromptLength {
+			return nil, aisec.NewAISecSDKError("codePrompt exceeds max length", aisec.UserRequestPayloadError)
+		}
+		c.codePrompt = opts.CodePrompt
+	}
+	if opts.CodeResponse != "" {
+		if len(opts.CodeResponse) > aisec.MaxContentResponseLength {
+			return nil, aisec.NewAISecSDKError("codeResponse exceeds max length", aisec.UserRequestPayloadError)
+		}
+		c.codeResponse = opts.CodeResponse
+	}
+	c.toolEvent = opts.ToolEvent
+
+	return c, nil
+}
+
+// Prompt returns the prompt text.
+func (c *Content) Prompt() string { return c.prompt }
+
+// Response returns the response text.
+func (c *Content) Response() string { return c.response }
+
+// Context returns the context text.
+func (c *Content) Context() string { return c.context }
+
+// CodePrompt returns the code prompt text.
+func (c *Content) CodePrompt() string { return c.codePrompt }
+
+// CodeResponse returns the code response text.
+func (c *Content) CodeResponse() string { return c.codeResponse }
+
+// ToolEvent returns the tool event.
+func (c *Content) ToolEvent() *ToolEvent { return c.toolEvent }
+
+// ByteLength returns the total byte length of all text content fields.
+func (c *Content) ByteLength() int {
+	return len(c.prompt) + len(c.response) + len(c.context) + len(c.codePrompt) + len(c.codeResponse)
+}
+
+// ToJSON serializes to the API request format.
+func (c *Content) ToJSON() ContentInner {
+	ci := ContentInner{}
+	if c.prompt != "" {
+		ci.Prompt = c.prompt
+	}
+	if c.response != "" {
+		ci.Response = c.response
+	}
+	if c.context != "" {
+		ci.Context = c.context
+	}
+	if c.codePrompt != "" {
+		ci.CodePrompt = c.codePrompt
+	}
+	if c.codeResponse != "" {
+		ci.CodeResponse = c.codeResponse
+	}
+	if c.toolEvent != nil {
+		ci.ToolEvent = c.toolEvent
+	}
+	return ci
+}
+
+// ContentFromJSON creates a Content from an API response object.
+func ContentFromJSON(ci ContentInner) (*Content, error) {
+	return NewContent(ContentOpts{
+		Prompt:       ci.Prompt,
+		Response:     ci.Response,
+		Context:      ci.Context,
+		CodePrompt:   ci.CodePrompt,
+		CodeResponse: ci.CodeResponse,
+		ToolEvent:    ci.ToolEvent,
+	})
+}

--- a/aisec/scan/content_test.go
+++ b/aisec/scan/content_test.go
@@ -1,0 +1,104 @@
+package scan
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+func TestNewContent_Valid(t *testing.T) {
+	c, err := NewContent(ContentOpts{Prompt: "hello", Response: "world"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Prompt() != "hello" {
+		t.Errorf("Prompt() = %q", c.Prompt())
+	}
+	if c.Response() != "world" {
+		t.Errorf("Response() = %q", c.Response())
+	}
+}
+
+func TestNewContent_RequiresAtLeastOneField(t *testing.T) {
+	_, err := NewContent(ContentOpts{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var sdkErr *aisec.AISecSDKError
+	if !errors.As(err, &sdkErr) {
+		t.Fatal("expected AISecSDKError")
+	}
+	if sdkErr.ErrorType != aisec.UserRequestPayloadError {
+		t.Errorf("ErrorType = %v", sdkErr.ErrorType)
+	}
+}
+
+func TestNewContent_PromptExceedsMaxLength(t *testing.T) {
+	bigStr := strings.Repeat("x", aisec.MaxContentPromptLength+1)
+	_, err := NewContent(ContentOpts{Prompt: bigStr})
+	if err == nil {
+		t.Fatal("expected error for oversized prompt")
+	}
+}
+
+func TestNewContent_ResponseExceedsMaxLength(t *testing.T) {
+	bigStr := strings.Repeat("x", aisec.MaxContentResponseLength+1)
+	_, err := NewContent(ContentOpts{Response: bigStr})
+	if err == nil {
+		t.Fatal("expected error for oversized response")
+	}
+}
+
+func TestNewContent_ContextExceedsMaxLength(t *testing.T) {
+	bigStr := strings.Repeat("x", aisec.MaxContentContextLength+1)
+	_, err := NewContent(ContentOpts{Prompt: "p", Context: bigStr})
+	if err == nil {
+		t.Fatal("expected error for oversized context")
+	}
+}
+
+func TestContent_ByteLength(t *testing.T) {
+	c, _ := NewContent(ContentOpts{Prompt: "hello", Response: "world"})
+	if c.ByteLength() != 10 {
+		t.Errorf("ByteLength() = %d, want 10", c.ByteLength())
+	}
+}
+
+func TestContent_ToJSON(t *testing.T) {
+	c, _ := NewContent(ContentOpts{Prompt: "p", Response: "r", Context: "c"})
+	j := c.ToJSON()
+	if j.Prompt != "p" || j.Response != "r" || j.Context != "c" {
+		t.Errorf("ToJSON = %+v", j)
+	}
+}
+
+func TestContent_WithToolEvent(t *testing.T) {
+	te := &ToolEvent{
+		Input:  "test input",
+		Output: "test output",
+	}
+	c, err := NewContent(ContentOpts{ToolEvent: te})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.ToolEvent() != te {
+		t.Error("ToolEvent not set")
+	}
+	j := c.ToJSON()
+	if j.ToolEvent == nil {
+		t.Error("ToolEvent not in JSON")
+	}
+}
+
+func TestContentFromJSON(t *testing.T) {
+	ci := ContentInner{Prompt: "hello", Response: "world"}
+	c, err := ContentFromJSON(ci)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.Prompt() != "hello" || c.Response() != "world" {
+		t.Error("ContentFromJSON mismatch")
+	}
+}

--- a/aisec/scan/models.go
+++ b/aisec/scan/models.go
@@ -1,0 +1,215 @@
+package scan
+
+// AiProfile identifies the security profile for scanning.
+type AiProfile struct {
+	ProfileID   string `json:"profile_id,omitempty"`
+	ProfileName string `json:"profile_name,omitempty"`
+}
+
+// Metadata holds application metadata attached to scan requests.
+type Metadata struct {
+	AppName   string     `json:"app_name,omitempty"`
+	AppUser   string     `json:"app_user,omitempty"`
+	AIModel   string     `json:"ai_model,omitempty"`
+	UserIP    string     `json:"user_ip,omitempty"`
+	AgentMeta *AgentMeta `json:"agent_meta,omitempty"`
+}
+
+// AgentMeta holds AI agent metadata.
+type AgentMeta struct {
+	AgentID      string `json:"agent_id,omitempty"`
+	AgentVersion string `json:"agent_version,omitempty"`
+	AgentARN     string `json:"agent_arn,omitempty"`
+}
+
+// ToolEvent represents a tool/function call event.
+type ToolEvent struct {
+	Metadata *ToolEventMetadata `json:"metadata,omitempty"`
+	Input    string             `json:"input,omitempty"`
+	Output   string             `json:"output,omitempty"`
+}
+
+// ToolEventMetadata holds tool event metadata.
+type ToolEventMetadata struct {
+	Ecosystem   string `json:"ecosystem"`
+	Method      string `json:"method"`
+	ServerName  string `json:"server_name"`
+	ToolInvoked string `json:"tool_invoked,omitempty"`
+}
+
+// ContentInner is the API wire format for a single content item.
+type ContentInner struct {
+	Prompt       string     `json:"prompt,omitempty"`
+	Response     string     `json:"response,omitempty"`
+	Context      string     `json:"context,omitempty"`
+	CodePrompt   string     `json:"code_prompt,omitempty"`
+	CodeResponse string     `json:"code_response,omitempty"`
+	ToolEvent    *ToolEvent `json:"tool_event,omitempty"`
+}
+
+// ScanRequest is the complete scan request payload.
+type ScanRequest struct {
+	AiProfile AiProfile       `json:"ai_profile"`
+	Contents  []ContentInner  `json:"contents"`
+	TrID      string          `json:"tr_id,omitempty"`
+	SessionID string          `json:"session_id,omitempty"`
+	Metadata  *Metadata       `json:"metadata,omitempty"`
+}
+
+// ScanResponse is the complete scan response from the AIRS API.
+type ScanResponse struct {
+	Source                   string                  `json:"source,omitempty"`
+	ReportID                 string                  `json:"report_id"`
+	ScanID                   string                  `json:"scan_id"`
+	TrID                     string                  `json:"tr_id,omitempty"`
+	SessionID                string                  `json:"session_id,omitempty"`
+	ProfileID                string                  `json:"profile_id,omitempty"`
+	ProfileName              string                  `json:"profile_name,omitempty"`
+	Category                 string                  `json:"category"`
+	Action                   string                  `json:"action"`
+	Timeout                  bool                    `json:"timeout,omitempty"`
+	Error                    bool                    `json:"error,omitempty"`
+	Errors                   []ContentError          `json:"errors,omitempty"`
+	PromptDetected           *PromptDetected         `json:"prompt_detected,omitempty"`
+	ResponseDetected         *ResponseDetected       `json:"response_detected,omitempty"`
+	PromptMaskedData         *MaskedData             `json:"prompt_masked_data,omitempty"`
+	ResponseMaskedData       *MaskedData             `json:"response_masked_data,omitempty"`
+	PromptDetectionDetails   map[string]any          `json:"prompt_detection_details,omitempty"`
+	ResponseDetectionDetails map[string]any          `json:"response_detection_details,omitempty"`
+	ToolDetected             *ToolDetected           `json:"tool_detected,omitempty"`
+	CreatedAt                string                  `json:"created_at,omitempty"`
+	CompletedAt              string                  `json:"completed_at,omitempty"`
+}
+
+// PromptDetected holds detection flags for the prompt.
+type PromptDetected struct {
+	URLCats        *bool `json:"url_cats,omitempty"`
+	DLP            *bool `json:"dlp,omitempty"`
+	Injection      *bool `json:"injection,omitempty"`
+	ToxicContent   *bool `json:"toxic_content,omitempty"`
+	MaliciousCode  *bool `json:"malicious_code,omitempty"`
+	Agent          *bool `json:"agent,omitempty"`
+	TopicViolation *bool `json:"topic_violation,omitempty"`
+}
+
+// ResponseDetected holds detection flags for the response.
+type ResponseDetected struct {
+	URLCats        *bool `json:"url_cats,omitempty"`
+	DLP            *bool `json:"dlp,omitempty"`
+	DBSecurity     *bool `json:"db_security,omitempty"`
+	ToxicContent   *bool `json:"toxic_content,omitempty"`
+	MaliciousCode  *bool `json:"malicious_code,omitempty"`
+	Agent          *bool `json:"agent,omitempty"`
+	Ungrounded     *bool `json:"ungrounded,omitempty"`
+	TopicViolation *bool `json:"topic_violation,omitempty"`
+}
+
+// MaskedData holds redacted content and pattern detections.
+type MaskedData struct {
+	Data              string             `json:"data,omitempty"`
+	PatternDetections []PatternDetection `json:"pattern_detections,omitempty"`
+}
+
+// PatternDetection represents a detected pattern in content.
+type PatternDetection struct {
+	Pattern string `json:"pattern,omitempty"`
+	Start   int    `json:"start,omitempty"`
+	End     int    `json:"end,omitempty"`
+}
+
+// ContentError represents an error that occurred during content scanning.
+type ContentError struct {
+	Type   string `json:"type,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// ToolDetected holds detection results for tool/agent interactions.
+type ToolDetected struct {
+	Verdict        string             `json:"verdict,omitempty"`
+	Metadata       *ToolEventMetadata `json:"metadata,omitempty"`
+	Summary        *ScanSummary       `json:"summary,omitempty"`
+	InputDetected  *IODetected        `json:"input_detected,omitempty"`
+	OutputDetected *IODetected        `json:"output_detected,omitempty"`
+}
+
+// ScanSummary holds verdict and action.
+type ScanSummary struct {
+	Verdict string `json:"verdict,omitempty"`
+	Action  string `json:"action,omitempty"`
+}
+
+// IODetected holds I/O detection flags.
+type IODetected struct {
+	URLCats       *bool `json:"url_cats,omitempty"`
+	DLP           *bool `json:"dlp,omitempty"`
+	Injection     *bool `json:"injection,omitempty"`
+	ToxicContent  *bool `json:"toxic_content,omitempty"`
+	MaliciousCode *bool `json:"malicious_code,omitempty"`
+}
+
+// AsyncScanObject is a batch item for async scanning.
+type AsyncScanObject struct {
+	AiProfile AiProfile      `json:"ai_profile"`
+	Contents  []ContentInner `json:"contents"`
+}
+
+// AsyncScanResponse is the async scan API response.
+type AsyncScanResponse struct {
+	Received string `json:"received,omitempty"`
+	ScanID   string `json:"scan_id,omitempty"`
+	ReportID string `json:"report_id,omitempty"`
+	Source   string `json:"source,omitempty"`
+}
+
+// ScanIDResult is the result of querying a scan by ID.
+type ScanIDResult struct {
+	Source string        `json:"source,omitempty"`
+	ReqID  int           `json:"req_id,omitempty"`
+	Status string        `json:"status,omitempty"`
+	ScanID string        `json:"scan_id,omitempty"`
+	Result *ScanResponse `json:"result,omitempty"`
+}
+
+// DetectionServiceResult holds results from a single detection service.
+type DetectionServiceResult struct {
+	ServiceName string         `json:"service_name,omitempty"`
+	Verdict     string         `json:"verdict,omitempty"`
+	Action      string         `json:"action,omitempty"`
+	Details     map[string]any `json:"details,omitempty"`
+}
+
+// ThreatScanReport is a detailed threat scan report.
+type ThreatScanReport struct {
+	Source           string                   `json:"source,omitempty"`
+	ReportID         string                   `json:"report_id,omitempty"`
+	ScanID           string                   `json:"scan_id,omitempty"`
+	ReqID            int                      `json:"req_id,omitempty"`
+	TransactionID    string                   `json:"transaction_id,omitempty"`
+	SessionID        string                   `json:"session_id,omitempty"`
+	DetectionResults []DetectionServiceResult  `json:"detection_results,omitempty"`
+}
+
+// Enums as string constants.
+const (
+	VerdictBenign    = "benign"
+	VerdictMalicious = "malicious"
+	VerdictUnknown   = "unknown"
+
+	ActionAllow = "allow"
+	ActionBlock = "block"
+	ActionAlert = "alert"
+
+	CategoryBenign    = "benign"
+	CategoryMalicious = "malicious"
+	CategoryUnknown   = "unknown"
+
+	DetectionServiceDLP            = "dlp"
+	DetectionServiceInjection      = "injection"
+	DetectionServiceURLCats        = "url_cats"
+	DetectionServiceToxicContent   = "toxic_content"
+	DetectionServiceMaliciousCode  = "malicious_code"
+	DetectionServiceAgent          = "agent"
+	DetectionServiceTopicViolation = "topic_violation"
+	DetectionServiceDBSecurity     = "db_security"
+	DetectionServiceUngrounded     = "ungrounded"
+)

--- a/aisec/scan/scanner.go
+++ b/aisec/scan/scanner.go
@@ -1,0 +1,146 @@
+package scan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+	"github.com/cdot65/prisma-airs-go/aisec/internal"
+)
+
+// SyncScanOpts are optional parameters for SyncScan.
+type SyncScanOpts struct {
+	TrID      string
+	SessionID string
+	Metadata  *Metadata
+}
+
+// Scanner is the client for AIRS scan operations.
+type Scanner struct {
+	cfg *aisec.Config
+}
+
+// NewScanner creates a new Scanner with the given configuration.
+func NewScanner(cfg *aisec.Config) *Scanner {
+	return &Scanner{cfg: cfg}
+}
+
+// SyncScan performs a synchronous content scan.
+func (s *Scanner) SyncScan(ctx context.Context, profile AiProfile, content *Content, opts ...SyncScanOpts) (*ScanResponse, error) {
+	var opt SyncScanOpts
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	if opt.TrID != "" && len(opt.TrID) > aisec.MaxTransactionIDLength {
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("trId exceeds max length of %d", aisec.MaxTransactionIDLength),
+			aisec.UserRequestPayloadError,
+		)
+	}
+	if opt.SessionID != "" && len(opt.SessionID) > aisec.MaxSessionIDLength {
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("sessionId exceeds max length of %d", aisec.MaxSessionIDLength),
+			aisec.UserRequestPayloadError,
+		)
+	}
+
+	body := map[string]any{
+		"ai_profile": profile,
+		"contents":   []ContentInner{content.ToJSON()},
+	}
+	if opt.TrID != "" {
+		body["tr_id"] = opt.TrID
+	}
+	if opt.SessionID != "" {
+		body["session_id"] = opt.SessionID
+	}
+	if opt.Metadata != nil {
+		body["metadata"] = opt.Metadata
+	}
+
+	resp, err := internal.DoRequest[ScanResponse](ctx, s.cfg, internal.RequestOptions{
+		Method: "POST",
+		Path:   aisec.SyncScanPath,
+		Body:   body,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// AsyncScan submits content for asynchronous scanning (1-5 items).
+func (s *Scanner) AsyncScan(ctx context.Context, objects []AsyncScanObject) (*AsyncScanResponse, error) {
+	if len(objects) < 1 {
+		return nil, aisec.NewAISecSDKError("at least 1 scan object is required", aisec.UserRequestPayloadError)
+	}
+	if len(objects) > aisec.MaxNumberOfBatchScanObjects {
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("max of %d scan objects allowed", aisec.MaxNumberOfBatchScanObjects),
+			aisec.UserRequestPayloadError,
+		)
+	}
+
+	resp, err := internal.DoRequest[AsyncScanResponse](ctx, s.cfg, internal.RequestOptions{
+		Method: "POST",
+		Path:   aisec.AsyncScanPath,
+		Body:   objects,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// QueryByScanIDs queries scan results by scan UUIDs (1-5 items).
+func (s *Scanner) QueryByScanIDs(ctx context.Context, scanIDs []string) ([]ScanIDResult, error) {
+	if len(scanIDs) < 1 {
+		return nil, aisec.NewAISecSDKError("at least 1 scan_id is required", aisec.UserRequestPayloadError)
+	}
+	if len(scanIDs) > aisec.MaxNumberOfScanIDs {
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("max of %d scan_ids allowed", aisec.MaxNumberOfScanIDs),
+			aisec.UserRequestPayloadError,
+		)
+	}
+	for _, id := range scanIDs {
+		if !aisec.IsValidUUID(id) {
+			return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan_id: %s", id), aisec.UserRequestPayloadError)
+		}
+	}
+
+	resp, err := internal.DoRequest[[]ScanIDResult](ctx, s.cfg, internal.RequestOptions{
+		Method: "GET",
+		Path:   aisec.ScanResultsPath,
+		Params: map[string]string{"scan_ids": strings.Join(scanIDs, ",")},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// QueryByReportIDs queries detailed threat reports by report IDs (1-5 items).
+func (s *Scanner) QueryByReportIDs(ctx context.Context, reportIDs []string) ([]ThreatScanReport, error) {
+	if len(reportIDs) < 1 {
+		return nil, aisec.NewAISecSDKError("at least 1 report_id is required", aisec.UserRequestPayloadError)
+	}
+	if len(reportIDs) > aisec.MaxNumberOfReportIDs {
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("max of %d report_ids allowed", aisec.MaxNumberOfReportIDs),
+			aisec.UserRequestPayloadError,
+		)
+	}
+
+	resp, err := internal.DoRequest[[]ThreatScanReport](ctx, s.cfg, internal.RequestOptions{
+		Method: "GET",
+		Path:   aisec.ScanReportsPath,
+		Params: map[string]string{"report_ids": strings.Join(reportIDs, ",")},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}

--- a/aisec/scan/scanner_test.go
+++ b/aisec/scan/scanner_test.go
@@ -1,0 +1,209 @@
+package scan
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+func TestScanner_SyncScan(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/scan/sync/request") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["ai_profile"] == nil {
+			t.Error("missing ai_profile")
+		}
+
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(ScanResponse{
+			ScanID:   "scan-123",
+			ReportID: "rpt-123",
+			Category: "benign",
+			Action:   "allow",
+		})
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("test-key"), aisec.WithEndpoint(server.URL))
+	scanner := NewScanner(cfg)
+	content, _ := NewContent(ContentOpts{Prompt: "hello"})
+
+	resp, err := scanner.SyncScan(context.Background(), AiProfile{ProfileName: "test"}, content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Category != "benign" {
+		t.Errorf("Category = %q", resp.Category)
+	}
+	if resp.ScanID != "scan-123" {
+		t.Errorf("ScanID = %q", resp.ScanID)
+	}
+}
+
+func TestScanner_SyncScan_TrIDTooLong(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+	content, _ := NewContent(ContentOpts{Prompt: "hello"})
+
+	_, err := scanner.SyncScan(context.Background(), AiProfile{ProfileName: "test"}, content, SyncScanOpts{
+		TrID: strings.Repeat("x", 101),
+	})
+	if err == nil {
+		t.Fatal("expected error for long trId")
+	}
+}
+
+func TestScanner_AsyncScan_EmptyObjects(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	_, err := scanner.AsyncScan(context.Background(), []AsyncScanObject{})
+	if err == nil {
+		t.Fatal("expected error for empty objects")
+	}
+}
+
+func TestScanner_AsyncScan_TooManyObjects(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	objects := make([]AsyncScanObject, 6)
+	_, err := scanner.AsyncScan(context.Background(), objects)
+	if err == nil {
+		t.Fatal("expected error for too many objects")
+	}
+}
+
+func TestScanner_QueryByScanIDs_Valid(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ids := r.URL.Query().Get("scan_ids")
+		if ids == "" {
+			t.Error("missing scan_ids param")
+		}
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode([]ScanIDResult{{ScanID: "test-id", Status: "completed"}})
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"), aisec.WithEndpoint(server.URL))
+	scanner := NewScanner(cfg)
+
+	results, err := scanner.QueryByScanIDs(context.Background(), []string{"550e8400-e29b-41d4-a716-446655440000"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len = %d", len(results))
+	}
+}
+
+func TestScanner_QueryByScanIDs_InvalidUUID(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	_, err := scanner.QueryByScanIDs(context.Background(), []string{"not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+	var sdkErr *aisec.AISecSDKError
+	if !errors.As(err, &sdkErr) || sdkErr.ErrorType != aisec.UserRequestPayloadError {
+		t.Errorf("wrong error type: %v", err)
+	}
+}
+
+func TestScanner_QueryByScanIDs_Empty(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	_, err := scanner.QueryByScanIDs(context.Background(), []string{})
+	if err == nil {
+		t.Fatal("expected error for empty IDs")
+	}
+}
+
+func TestScanner_QueryByScanIDs_TooMany(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	ids := make([]string, 6)
+	for i := range ids {
+		ids[i] = "550e8400-e29b-41d4-a716-446655440000"
+	}
+	_, err := scanner.QueryByScanIDs(context.Background(), ids)
+	if err == nil {
+		t.Fatal("expected error for too many IDs")
+	}
+}
+
+func TestScanner_QueryByReportIDs_Valid(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode([]ThreatScanReport{{ReportID: "rpt-1"}})
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"), aisec.WithEndpoint(server.URL))
+	scanner := NewScanner(cfg)
+
+	reports, err := scanner.QueryByReportIDs(context.Background(), []string{"rpt-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len = %d", len(reports))
+	}
+}
+
+func TestScanner_QueryByReportIDs_Empty(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	_, err := scanner.QueryByReportIDs(context.Background(), []string{})
+	if err == nil {
+		t.Fatal("expected error for empty IDs")
+	}
+}
+
+func TestScanner_QueryByReportIDs_TooMany(t *testing.T) {
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"))
+	scanner := NewScanner(cfg)
+
+	_, err := scanner.QueryByReportIDs(context.Background(), make([]string, 6))
+	if err == nil {
+		t.Fatal("expected error for too many IDs")
+	}
+}
+
+func TestModels_JSONSerialization(t *testing.T) {
+	resp := ScanResponse{
+		ScanID:   "scan-1",
+		ReportID: "rpt-1",
+		Category: VerdictBenign,
+		Action:   ActionAllow,
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded ScanResponse
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ScanID != "scan-1" || decoded.Category != "benign" {
+		t.Errorf("decoded = %+v", decoded)
+	}
+}


### PR DESCRIPTION
## Summary
- Scanner: SyncScan, AsyncScan, QueryByScanIDs, QueryByReportIDs
- Content: byte-length validation, ToJSON/FromJSON, ByteLength
- Models: ScanResponse, AsyncScanResponse, ScanIDResult, ThreatScanReport, all detection types
- Enums: Verdict, Action, Category, DetectionService constants
- Input validation: batch limits (1-5), UUID format, string lengths

## Test plan
- [x] 20 tests passing with race detector
- [x] Content validation (empty, oversized, valid)
- [x] Scanner methods with mock HTTP
- [x] Batch limit enforcement
- [x] UUID validation
- [x] JSON serialization round-trip

Closes #6