### PR TITLE
feat: OAuth client — token lifecycle management

### DIFF
--- a/aisec/internal/mgmthttpclient.go
+++ b/aisec/internal/mgmthttpclient.go
@@ -1,0 +1,100 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+// MgmtRequestOptions for an OAuth-authenticated HTTP request.
+type MgmtRequestOptions struct {
+	Method string
+	Path   string
+	Body   any
+	Params map[string]string
+}
+
+// DoMgmtRequest performs an OAuth-authenticated HTTP request with retry.
+func DoMgmtRequest[T any](ctx context.Context, svcCfg *OAuthServiceConfig, opts MgmtRequestOptions) (*Response[T], error) {
+	baseURL := svcCfg.BaseURL
+
+	u, err := url.Parse(baseURL + opts.Path)
+	if err != nil {
+		return nil, aisec.WrapError(fmt.Sprintf("invalid URL: %s%s", baseURL, opts.Path), aisec.AISecSDKInternalError, err)
+	}
+
+	if opts.Params != nil {
+		q := u.Query()
+		for k, v := range opts.Params {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+	}
+
+	var bodyBytes []byte
+	if opts.Body != nil {
+		bodyBytes, err = json.Marshal(opts.Body)
+		if err != nil {
+			return nil, aisec.WrapError("failed to marshal request body", aisec.AISecSDKInternalError, err)
+		}
+	}
+
+	resp, err := ExecuteWithRetry(RetryOptions{
+		MaxRetries: svcCfg.NumRetries,
+		Execute: func(attempt int) (*http.Response, error) {
+			token, err := svcCfg.OAuth.GetToken()
+			if err != nil {
+				return nil, err
+			}
+
+			var bodyReader io.Reader
+			if bodyBytes != nil {
+				bodyReader = bytes.NewReader(bodyBytes)
+			}
+
+			req, err := http.NewRequestWithContext(ctx, opts.Method, u.String(), bodyReader)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("User-Agent", aisec.UserAgent)
+			req.Header.Set(aisec.HeaderAuthToken, aisec.Bearer+token)
+
+			return http.DefaultClient.Do(req)
+		},
+		OnRetryableFailure: func(resp *http.Response, attempt int) (bool, error) {
+			if resp.StatusCode == 401 || resp.StatusCode == 403 {
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				svcCfg.OAuth.ClearToken()
+				return true, nil // retry without consuming budget
+			}
+			return false, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, aisec.WrapError("failed to read response body", aisec.AISecSDKInternalError, err)
+	}
+
+	var data T
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &data); err != nil {
+			return nil, aisec.WrapError("failed to parse response JSON", aisec.AISecSDKInternalError, err)
+		}
+	}
+
+	return &Response[T]{Status: resp.StatusCode, Data: data}, nil
+}

--- a/aisec/internal/oauth.go
+++ b/aisec/internal/oauth.go
@@ -1,0 +1,226 @@
+package internal
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+const defaultTokenBufferMs = 30_000 // refresh 30s before expiry
+
+// TokenInfo is a snapshot of the current token state (never exposes the actual token).
+type TokenInfo struct {
+	HasToken       bool
+	IsValid        bool
+	IsExpired      bool
+	IsExpiringSoon bool
+	ExpiresIn      time.Duration
+	ExpiresAt      time.Time
+}
+
+// OAuthClientOpts are options for creating an OAuthClient.
+type OAuthClientOpts struct {
+	ClientID      string
+	ClientSecret  string
+	TsgID         string
+	TokenEndpoint string
+	TokenBufferMs int
+}
+
+// OAuthClient manages OAuth2 client_credentials tokens with caching and proactive refresh.
+type OAuthClient struct {
+	clientID      string
+	clientSecret  string
+	tsgID         string
+	tokenEndpoint string
+	tokenBufferMs time.Duration
+
+	mu          sync.Mutex
+	accessToken string
+	expiresAt   time.Time
+	fetching    bool
+	fetchCh     chan struct{} // closed when fetch completes
+}
+
+// NewOAuthClient creates a new OAuth2 client.
+func NewOAuthClient(opts OAuthClientOpts) *OAuthClient {
+	endpoint := opts.TokenEndpoint
+	if endpoint == "" {
+		endpoint = aisec.DefaultTokenEndpoint
+	}
+	bufferMs := opts.TokenBufferMs
+	if bufferMs <= 0 {
+		bufferMs = defaultTokenBufferMs
+	}
+
+	return &OAuthClient{
+		clientID:      opts.ClientID,
+		clientSecret:  opts.ClientSecret,
+		tsgID:         opts.TsgID,
+		tokenEndpoint: endpoint,
+		tokenBufferMs: time.Duration(bufferMs) * time.Millisecond,
+	}
+}
+
+// GetToken returns a valid access token, fetching/refreshing as needed.
+// Concurrent calls are deduplicated — only one fetch happens at a time.
+func (c *OAuthClient) GetToken() (string, error) {
+	c.mu.Lock()
+
+	// Return cached token if valid
+	if c.accessToken != "" && time.Now().Before(c.expiresAt.Add(-c.tokenBufferMs)) {
+		token := c.accessToken
+		c.mu.Unlock()
+		return token, nil
+	}
+
+	// If another goroutine is already fetching, wait for it
+	if c.fetching {
+		ch := c.fetchCh
+		c.mu.Unlock()
+		<-ch
+		c.mu.Lock()
+		token := c.accessToken
+		c.mu.Unlock()
+		if token == "" {
+			return "", aisec.NewAISecSDKError("token fetch failed", aisec.OAuthError)
+		}
+		return token, nil
+	}
+
+	// Start fetch
+	c.fetching = true
+	c.fetchCh = make(chan struct{})
+	c.mu.Unlock()
+
+	token, err := c.fetchToken()
+
+	c.mu.Lock()
+	c.fetching = false
+	close(c.fetchCh)
+	c.mu.Unlock()
+
+	return token, err
+}
+
+// ClearToken invalidates the cached token.
+func (c *OAuthClient) ClearToken() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.accessToken = ""
+	c.expiresAt = time.Time{}
+}
+
+// IsTokenExpired returns true if the token is expired or doesn't exist.
+func (c *OAuthClient) IsTokenExpired() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.accessToken == "" || time.Now().After(c.expiresAt)
+}
+
+// IsTokenExpiringSoon returns true if the token is within the pre-expiry buffer.
+func (c *OAuthClient) IsTokenExpiringSoon() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.accessToken == "" || time.Now().After(c.expiresAt.Add(-c.tokenBufferMs))
+}
+
+// GetTokenInfo returns a snapshot of the current token state.
+func (c *OAuthClient) GetTokenInfo() TokenInfo {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	hasToken := c.accessToken != ""
+	isExpired := !hasToken || now.After(c.expiresAt)
+	isExpiringSoon := !hasToken || now.After(c.expiresAt.Add(-c.tokenBufferMs))
+
+	var expiresIn time.Duration
+	var expiresAt time.Time
+	if hasToken {
+		expiresIn = c.expiresAt.Sub(now)
+		if expiresIn < 0 {
+			expiresIn = 0
+		}
+		expiresAt = c.expiresAt
+	}
+
+	return TokenInfo{
+		HasToken:       hasToken,
+		IsValid:        hasToken && !isExpiringSoon,
+		IsExpired:      isExpired,
+		IsExpiringSoon: isExpiringSoon,
+		ExpiresIn:      expiresIn,
+		ExpiresAt:      expiresAt,
+	}
+}
+
+// TokenEndpoint returns the configured token endpoint URL.
+func (c *OAuthClient) TokenEndpoint() string {
+	return c.tokenEndpoint
+}
+
+type oauthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+func (c *OAuthClient) fetchToken() (string, error) {
+	credentials := base64.StdEncoding.EncodeToString(
+		[]byte(c.clientID + ":" + c.clientSecret),
+	)
+
+	form := url.Values{
+		"grant_type": {"client_credentials"},
+		"scope":      {fmt.Sprintf("tsg_id:%s", c.tsgID)},
+	}
+
+	req, err := http.NewRequest("POST", c.tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", aisec.WrapError("failed to create token request", aisec.OAuthError, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+credentials)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", aisec.WrapError(fmt.Sprintf("token request failed: %s", err.Error()), aisec.OAuthError, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		var errBody map[string]any
+		msg := fmt.Sprintf("Token request failed with status %d", resp.StatusCode)
+		if json.Unmarshal(body, &errBody) == nil {
+			if desc, ok := errBody["error_description"].(string); ok {
+				msg = desc
+			} else if errStr, ok := errBody["error"].(string); ok {
+				msg = errStr
+			}
+		}
+		return "", aisec.NewAISecSDKError(msg, aisec.OAuthError)
+	}
+
+	var tokenResp oauthTokenResponse
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", aisec.WrapError("failed to parse token response", aisec.OAuthError, err)
+	}
+
+	c.mu.Lock()
+	c.accessToken = tokenResp.AccessToken
+	c.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
+	c.mu.Unlock()
+
+	return tokenResp.AccessToken, nil
+}

--- a/aisec/internal/oauth_test.go
+++ b/aisec/internal/oauth_test.go
@@ -1,0 +1,248 @@
+package internal
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newTestOAuthServer(t *testing.T, expiresIn int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("content-type = %s", r.Header.Get("Content-Type"))
+		}
+		auth := r.Header.Get("Authorization")
+		if auth == "" {
+			t.Error("missing Authorization header")
+		}
+
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token-123",
+			"expires_in":   expiresIn,
+			"token_type":   "Bearer",
+		})
+	}))
+}
+
+func TestOAuthClient_GetToken(t *testing.T) {
+	server := newTestOAuthServer(t, 3600)
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	token, err := client.GetToken()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "test-token-123" {
+		t.Errorf("token = %q", token)
+	}
+}
+
+func TestOAuthClient_TokenCaching(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "cached-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	// First call fetches
+	client.GetToken()
+	// Second call should use cache
+	token, _ := client.GetToken()
+	if token != "cached-token" {
+		t.Errorf("token = %q", token)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("fetch calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestOAuthClient_ClearToken(t *testing.T) {
+	server := newTestOAuthServer(t, 3600)
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	client.GetToken()
+	info := client.GetTokenInfo()
+	if !info.HasToken {
+		t.Error("should have token after GetToken")
+	}
+
+	client.ClearToken()
+	info = client.GetTokenInfo()
+	if info.HasToken {
+		t.Error("should not have token after ClearToken")
+	}
+}
+
+func TestOAuthClient_TokenInfo(t *testing.T) {
+	server := newTestOAuthServer(t, 3600)
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	// Before fetch
+	info := client.GetTokenInfo()
+	if info.HasToken {
+		t.Error("should not have token initially")
+	}
+	if info.IsValid {
+		t.Error("should not be valid without token")
+	}
+	if !info.IsExpired {
+		t.Error("should be expired without token")
+	}
+
+	// After fetch
+	client.GetToken()
+	info = client.GetTokenInfo()
+	if !info.HasToken {
+		t.Error("should have token")
+	}
+	if !info.IsValid {
+		t.Error("should be valid")
+	}
+	if info.IsExpired {
+		t.Error("should not be expired")
+	}
+	if info.ExpiresIn <= 0 {
+		t.Errorf("ExpiresIn = %v", info.ExpiresIn)
+	}
+}
+
+func TestOAuthClient_ConcurrentDeduplication(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond) // simulate latency
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "dedup-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			token, err := client.GetToken()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if token != "dedup-token" {
+				t.Errorf("token = %q", token)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if calls.Load() != 1 {
+		t.Errorf("fetch calls = %d, want 1 (deduplication failed)", calls.Load())
+	}
+}
+
+func TestOAuthClient_ErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_client",
+			"error_description": "bad credentials",
+		})
+	}))
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "bad-id",
+		ClientSecret:  "bad-secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+	})
+
+	_, err := client.GetToken()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOAuthClient_IsTokenExpired(t *testing.T) {
+	server := newTestOAuthServer(t, 1) // 1 second expiry
+	defer server.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: server.URL,
+		TokenBufferMs: 100, // small buffer for test
+	})
+
+	if !client.IsTokenExpired() {
+		t.Error("should be expired without token")
+	}
+
+	client.GetToken()
+	if client.IsTokenExpired() {
+		t.Error("should not be expired right after fetch")
+	}
+}
+
+func TestOAuthClient_DefaultTokenEndpoint(t *testing.T) {
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:     "id",
+		ClientSecret: "secret",
+		TsgID:        "123",
+	})
+	if client.TokenEndpoint() != "https://auth.apps.paloaltonetworks.com/oauth2/access_token" {
+		t.Errorf("endpoint = %q", client.TokenEndpoint())
+	}
+}

--- a/aisec/internal/oauthconfig.go
+++ b/aisec/internal/oauthconfig.go
@@ -1,0 +1,119 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+// OAuthServiceConfig is the resolved OAuth configuration for a service.
+type OAuthServiceConfig struct {
+	BaseURL    string
+	OAuth      *OAuthClient
+	NumRetries int
+	TsgID      string
+}
+
+// ResolveOAuthConfigOpts are options for resolving OAuth config.
+type ResolveOAuthConfigOpts struct {
+	ClientID         string
+	ClientSecret     string
+	TsgID            string
+	BaseURL          string
+	NumRetries       int
+	TokenEndpoint    string
+	TokenBufferMs    int
+	PrimaryEnvPrefix string // e.g. "PANW_RED_TEAM"
+	FallbackEnvPrefix string // e.g. "PANW_MGMT"
+}
+
+// ResolveOAuthConfig resolves OAuth2 credentials from options -> primary env vars -> fallback env vars.
+func ResolveOAuthConfig(opts ResolveOAuthConfigOpts) (*OAuthServiceConfig, error) {
+	clientID := firstNonEmpty(opts.ClientID,
+		os.Getenv(opts.PrimaryEnvPrefix+"_CLIENT_ID"),
+		envOrEmpty(opts.FallbackEnvPrefix, "_CLIENT_ID"),
+	)
+	clientSecret := firstNonEmpty(opts.ClientSecret,
+		os.Getenv(opts.PrimaryEnvPrefix+"_CLIENT_SECRET"),
+		envOrEmpty(opts.FallbackEnvPrefix, "_CLIENT_SECRET"),
+	)
+	tsgID := firstNonEmpty(opts.TsgID,
+		os.Getenv(opts.PrimaryEnvPrefix+"_TSG_ID"),
+		envOrEmpty(opts.FallbackEnvPrefix, "_TSG_ID"),
+	)
+	tokenEndpoint := firstNonEmpty(opts.TokenEndpoint,
+		os.Getenv(opts.PrimaryEnvPrefix+"_TOKEN_ENDPOINT"),
+		envOrEmpty(opts.FallbackEnvPrefix, "_TOKEN_ENDPOINT"),
+	)
+
+	numRetries := opts.NumRetries
+	if numRetries < 0 {
+		numRetries = 0
+	}
+	if numRetries > aisec.MaxNumberOfRetries {
+		numRetries = aisec.MaxNumberOfRetries
+	}
+
+	if clientID == "" {
+		hint := opts.PrimaryEnvPrefix + "_CLIENT_ID"
+		if opts.FallbackEnvPrefix != "" {
+			hint += " / " + opts.FallbackEnvPrefix + "_CLIENT_ID"
+		}
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("clientId is required (option or %s env var)", hint),
+			aisec.MissingVariableError,
+		)
+	}
+	if clientSecret == "" {
+		hint := opts.PrimaryEnvPrefix + "_CLIENT_SECRET"
+		if opts.FallbackEnvPrefix != "" {
+			hint += " / " + opts.FallbackEnvPrefix + "_CLIENT_SECRET"
+		}
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("clientSecret is required (option or %s env var)", hint),
+			aisec.MissingVariableError,
+		)
+	}
+	if tsgID == "" {
+		hint := opts.PrimaryEnvPrefix + "_TSG_ID"
+		if opts.FallbackEnvPrefix != "" {
+			hint += " / " + opts.FallbackEnvPrefix + "_TSG_ID"
+		}
+		return nil, aisec.NewAISecSDKError(
+			fmt.Sprintf("tsgId is required (option or %s env var)", hint),
+			aisec.MissingVariableError,
+		)
+	}
+
+	oauthClient := NewOAuthClient(OAuthClientOpts{
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		TsgID:         tsgID,
+		TokenEndpoint: tokenEndpoint,
+		TokenBufferMs: opts.TokenBufferMs,
+	})
+
+	return &OAuthServiceConfig{
+		BaseURL:    opts.BaseURL,
+		OAuth:      oauthClient,
+		NumRetries: numRetries,
+		TsgID:      tsgID,
+	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func envOrEmpty(prefix, suffix string) string {
+	if prefix == "" {
+		return ""
+	}
+	return os.Getenv(prefix + suffix)
+}

--- a/aisec/internal/oauthconfig_test.go
+++ b/aisec/internal/oauthconfig_test.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+)
+
+func TestResolveOAuthConfig_Explicit(t *testing.T) {
+	cfg, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		ClientID:         "my-id",
+		ClientSecret:     "my-secret",
+		TsgID:            "123",
+		BaseURL:          "https://api.example.com",
+		NumRetries:       3,
+		PrimaryEnvPrefix: "PANW_TEST",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseURL != "https://api.example.com" {
+		t.Errorf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.NumRetries != 3 {
+		t.Errorf("NumRetries = %d", cfg.NumRetries)
+	}
+	if cfg.TsgID != "123" {
+		t.Errorf("TsgID = %q", cfg.TsgID)
+	}
+}
+
+func TestResolveOAuthConfig_FromEnv(t *testing.T) {
+	t.Setenv("PANW_TEST_CLIENT_ID", "env-id")
+	t.Setenv("PANW_TEST_CLIENT_SECRET", "env-secret")
+	t.Setenv("PANW_TEST_TSG_ID", "456")
+
+	cfg, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		BaseURL:          "https://api.example.com",
+		PrimaryEnvPrefix: "PANW_TEST",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TsgID != "456" {
+		t.Errorf("TsgID = %q", cfg.TsgID)
+	}
+}
+
+func TestResolveOAuthConfig_Fallback(t *testing.T) {
+	t.Setenv("PANW_MGMT_CLIENT_ID", "fallback-id")
+	t.Setenv("PANW_MGMT_CLIENT_SECRET", "fallback-secret")
+	t.Setenv("PANW_MGMT_TSG_ID", "789")
+
+	cfg, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		BaseURL:           "https://api.example.com",
+		PrimaryEnvPrefix:  "PANW_MODEL_SEC",
+		FallbackEnvPrefix: "PANW_MGMT",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TsgID != "789" {
+		t.Errorf("TsgID = %q", cfg.TsgID)
+	}
+}
+
+func TestResolveOAuthConfig_MissingClientID(t *testing.T) {
+	_, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		ClientSecret:     "secret",
+		TsgID:            "123",
+		BaseURL:          "https://api.example.com",
+		PrimaryEnvPrefix: "PANW_EMPTY",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing clientId")
+	}
+	var sdkErr *aisec.AISecSDKError
+	if !errors.As(err, &sdkErr) || sdkErr.ErrorType != aisec.MissingVariableError {
+		t.Errorf("wrong error: %v", err)
+	}
+}
+
+func TestResolveOAuthConfig_MissingClientSecret(t *testing.T) {
+	_, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		ClientID:         "id",
+		TsgID:            "123",
+		BaseURL:          "https://api.example.com",
+		PrimaryEnvPrefix: "PANW_EMPTY",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing clientSecret")
+	}
+}
+
+func TestResolveOAuthConfig_MissingTsgID(t *testing.T) {
+	_, err := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		BaseURL:          "https://api.example.com",
+		PrimaryEnvPrefix: "PANW_EMPTY",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing tsgId")
+	}
+}
+
+func TestResolveOAuthConfig_RetriesClamped(t *testing.T) {
+	cfg, _ := ResolveOAuthConfig(ResolveOAuthConfigOpts{
+		ClientID:         "id",
+		ClientSecret:     "secret",
+		TsgID:            "123",
+		BaseURL:          "https://api.example.com",
+		NumRetries:       99,
+		PrimaryEnvPrefix: "PANW_TEST",
+	})
+	if cfg.NumRetries != aisec.MaxNumberOfRetries {
+		t.Errorf("NumRetries = %d", cfg.NumRetries)
+	}
+}


### PR DESCRIPTION
## Summary
- OAuth2 client_credentials with token caching, proactive refresh (30s buffer)
- Concurrent GetToken() deduplication (single inflight fetch)
- TokenInfo snapshot (never exposes raw token)
- ResolveOAuthConfig: env var fallback chain (service-specific → MGMT)
- DoMgmtRequest: bearer token injection with 401/403 auto-retry

## Test plan
- [x] All tests pass with race detector
- [x] Token caching verified (single fetch for multiple calls)
- [x] Concurrent deduplication (10 goroutines, 1 fetch)
- [x] ClearToken invalidation
- [x] TokenInfo state correctness
- [x] OAuth config env var resolution + fallback
- [x] Missing credential error messages

Closes #7