### PR TITLE
feat(modelsecurity): Model Security API client with dual-endpoint routing

### DIFF
--- a/aisec/modelsecurity/client.go
+++ b/aisec/modelsecurity/client.go
@@ -1,0 +1,554 @@
+package modelsecurity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+	"github.com/cdot65/prisma-airs-go/aisec/internal"
+)
+
+// Opts are options for creating a ModelSecurityClient.
+type Opts struct {
+	ClientID      string
+	ClientSecret  string
+	TsgID         string
+	DataEndpoint  string
+	MgmtEndpoint  string
+	TokenEndpoint string
+	NumRetries    int
+}
+
+// Client is the Model Security API client with dual-endpoint routing.
+type Client struct {
+	Scans          *ScansClient
+	SecurityGroups *SecurityGroupsClient
+	SecurityRules  *SecurityRulesClient
+
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+// NewClient creates a new Model Security API client.
+func NewClient(opts Opts) (*Client, error) {
+	dataEndpoint := opts.DataEndpoint
+	if dataEndpoint == "" {
+		dataEndpoint = aisec.DefaultModelSecDataEndpoint
+	}
+
+	mgmtEndpoint := opts.MgmtEndpoint
+	if mgmtEndpoint == "" {
+		mgmtEndpoint = aisec.DefaultModelSecMgmtEndpoint
+	}
+
+	mgmtCfg, err := internal.ResolveOAuthConfig(internal.ResolveOAuthConfigOpts{
+		ClientID:          opts.ClientID,
+		ClientSecret:      opts.ClientSecret,
+		TsgID:             opts.TsgID,
+		BaseURL:           mgmtEndpoint,
+		NumRetries:        opts.NumRetries,
+		TokenEndpoint:     opts.TokenEndpoint,
+		PrimaryEnvPrefix:  "PANW_MODEL_SEC",
+		FallbackEnvPrefix: "PANW_MGMT",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Data plane config shares the same OAuth client but different base URL.
+	dataCfg := &internal.OAuthServiceConfig{
+		BaseURL:    dataEndpoint,
+		OAuth:      mgmtCfg.OAuth,
+		NumRetries: mgmtCfg.NumRetries,
+		TsgID:      mgmtCfg.TsgID,
+	}
+
+	c := &Client{mgmtCfg: mgmtCfg}
+	c.Scans = &ScansClient{dataCfg: dataCfg}
+	c.SecurityGroups = &SecurityGroupsClient{mgmtCfg: mgmtCfg}
+	c.SecurityRules = &SecurityRulesClient{mgmtCfg: mgmtCfg}
+
+	return c, nil
+}
+
+// GetPyPIAuth gets PyPI authentication credentials for Google Artifact Registry.
+func (c *Client) GetPyPIAuth(ctx context.Context) (*PyPIAuthResponse, error) {
+	resp, err := internal.DoMgmtRequest[PyPIAuthResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecPyPIAuthPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Scans Client (data plane) ---
+
+// ScansClient provides model security scan operations via the data plane.
+type ScansClient struct {
+	dataCfg *internal.OAuthServiceConfig
+}
+
+func (c *ScansClient) Create(ctx context.Context, req ScanCreateRequest) (*ScanBaseResponse, error) {
+	resp, err := internal.DoMgmtRequest[ScanBaseResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.ModelSecScansPath, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) List(ctx context.Context, opts ScanListOpts) (*ScanList, error) {
+	resp, err := internal.DoMgmtRequest[ScanList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath, Params: buildScanListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) Get(ctx context.Context, uuid string) (*ScanBaseResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ScanBaseResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetEvaluations(ctx context.Context, scanUUID string, opts EvaluationListOpts) (*RuleEvaluationList, error) {
+	if !aisec.IsValidUUID(scanUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[RuleEvaluationList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/" + scanUUID + "/evaluations", Params: buildEvaluationListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetEvaluation(ctx context.Context, uuid string) (*RuleEvaluationResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid evaluation uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[RuleEvaluationResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecEvaluationsPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetFiles(ctx context.Context, scanUUID string, opts FileListOpts) (*FileList, error) {
+	if !aisec.IsValidUUID(scanUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[FileList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/" + scanUUID + "/files", Params: buildFileListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetViolations(ctx context.Context, scanUUID string, opts ViolationListOpts) (*ViolationList, error) {
+	if !aisec.IsValidUUID(scanUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ViolationList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/" + scanUUID + "/rule-violations", Params: buildViolationListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetViolation(ctx context.Context, uuid string) (*ViolationResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid violation uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ViolationResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecViolationsPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) AddLabels(ctx context.Context, scanUUID string, req LabelsCreateRequest) (*LabelsResponse, error) {
+	if !aisec.IsValidUUID(scanUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[LabelsResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.ModelSecScansPath + "/" + scanUUID + "/labels", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) SetLabels(ctx context.Context, scanUUID string, req LabelsCreateRequest) (*LabelsResponse, error) {
+	if !aisec.IsValidUUID(scanUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[LabelsResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.ModelSecScansPath + "/" + scanUUID + "/labels", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) DeleteLabels(ctx context.Context, scanUUID string, keys []string) error {
+	if !aisec.IsValidUUID(scanUUID) {
+		return aisec.NewAISecSDKError(fmt.Sprintf("invalid scan uuid: %s", scanUUID), aisec.UserRequestPayloadError)
+	}
+	// Build repeated query params: ?keys=key1&keys=key2
+	q := url.Values{}
+	for _, k := range keys {
+		q.Add("keys", k)
+	}
+	path := aisec.ModelSecScansPath + "/" + scanUUID + "/labels"
+	if qs := q.Encode(); qs != "" {
+		path += "?" + qs
+	}
+	_, err := internal.DoMgmtRequest[any](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodDelete, Path: path,
+	})
+	return err
+}
+
+func (c *ScansClient) GetLabelKeys(ctx context.Context, opts LabelListOpts) (*LabelKeyList, error) {
+	resp, err := internal.DoMgmtRequest[LabelKeyList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/label-keys", Params: buildLabelListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetLabelValues(ctx context.Context, key string, opts LabelListOpts) (*LabelValueList, error) {
+	resp, err := internal.DoMgmtRequest[LabelValueList](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecScansPath + "/label-keys/" + url.PathEscape(key) + "/values", Params: buildLabelListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Security Groups Client (mgmt plane) ---
+
+// SecurityGroupsClient provides security group CRUD and nested rule instance operations.
+type SecurityGroupsClient struct {
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+func (c *SecurityGroupsClient) Create(ctx context.Context, req ModelSecurityGroupCreateRequest) (*ModelSecurityGroupResponse, error) {
+	resp, err := internal.DoMgmtRequest[ModelSecurityGroupResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.ModelSecSecurityGroupsPath, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) List(ctx context.Context, opts GroupListOpts) (*ListModelSecurityGroupsResponse, error) {
+	resp, err := internal.DoMgmtRequest[ListModelSecurityGroupsResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityGroupsPath, Params: buildGroupListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) Get(ctx context.Context, uuid string) (*ModelSecurityGroupResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ModelSecurityGroupResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityGroupsPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) Update(ctx context.Context, uuid string, req ModelSecurityGroupUpdateRequest) (*ModelSecurityGroupResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ModelSecurityGroupResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.ModelSecSecurityGroupsPath + "/" + uuid, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) Delete(ctx context.Context, uuid string) error {
+	if !aisec.IsValidUUID(uuid) {
+		return aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	_, err := internal.DoMgmtRequest[any](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodDelete, Path: aisec.ModelSecSecurityGroupsPath + "/" + uuid,
+	})
+	return err
+}
+
+func (c *SecurityGroupsClient) ListRuleInstances(ctx context.Context, sgUUID string, opts RuleInstanceListOpts) (*ListModelSecurityRuleInstancesResponse, error) {
+	if !aisec.IsValidUUID(sgUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", sgUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ListModelSecurityRuleInstancesResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityGroupsPath + "/" + sgUUID + "/rule-instances", Params: buildRuleInstanceListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) GetRuleInstance(ctx context.Context, sgUUID, riUUID string) (*ModelSecurityRuleInstanceResponse, error) {
+	if !aisec.IsValidUUID(sgUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", sgUUID), aisec.UserRequestPayloadError)
+	}
+	if !aisec.IsValidUUID(riUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid rule instance uuid: %s", riUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ModelSecurityRuleInstanceResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityGroupsPath + "/" + sgUUID + "/rule-instances/" + riUUID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityGroupsClient) UpdateRuleInstance(ctx context.Context, sgUUID, riUUID string, req ModelSecurityRuleInstanceUpdateRequest) (*ModelSecurityRuleInstanceResponse, error) {
+	if !aisec.IsValidUUID(sgUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security group uuid: %s", sgUUID), aisec.UserRequestPayloadError)
+	}
+	if !aisec.IsValidUUID(riUUID) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid rule instance uuid: %s", riUUID), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ModelSecurityRuleInstanceResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.ModelSecSecurityGroupsPath + "/" + sgUUID + "/rule-instances/" + riUUID, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Security Rules Client (mgmt plane, read-only) ---
+
+// SecurityRulesClient provides read-only access to security rules.
+type SecurityRulesClient struct {
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+func (c *SecurityRulesClient) List(ctx context.Context, opts RuleListOpts) (*ListModelSecurityRulesResponse, error) {
+	resp, err := internal.DoMgmtRequest[ListModelSecurityRulesResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityRulesPath, Params: buildRuleListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *SecurityRulesClient) Get(ctx context.Context, uuid string) (*ModelSecurityRuleResponse, error) {
+	if !aisec.IsValidUUID(uuid) {
+		return nil, aisec.NewAISecSDKError(fmt.Sprintf("invalid security rule uuid: %s", uuid), aisec.UserRequestPayloadError)
+	}
+	resp, err := internal.DoMgmtRequest[ModelSecurityRuleResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.ModelSecSecurityRulesPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Param builders ---
+
+func buildScanListParams(opts ScanListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SortBy != "" {
+		params["sort_by"] = opts.SortBy
+	}
+	if opts.SortOrder != "" {
+		params["sort_order"] = opts.SortOrder
+	}
+	if opts.SearchQuery != "" {
+		params["search_query"] = opts.SearchQuery
+	}
+	if opts.SecurityGroupUUID != "" {
+		params["security_group_uuid"] = opts.SecurityGroupUUID
+	}
+	if opts.StartTime != "" {
+		params["start_time"] = opts.StartTime
+	}
+	if opts.EndTime != "" {
+		params["end_time"] = opts.EndTime
+	}
+	if opts.LabelsQuery != "" {
+		params["labels_query"] = opts.LabelsQuery
+	}
+	return params
+}
+
+func buildEvaluationListParams(opts EvaluationListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SortField != "" {
+		params["sort_field"] = opts.SortField
+	}
+	if opts.SortOrder != "" {
+		params["sort_order"] = opts.SortOrder
+	}
+	if opts.Result != "" {
+		params["result"] = opts.Result
+	}
+	if opts.RuleInstanceUUID != "" {
+		params["rule_instance_uuid"] = opts.RuleInstanceUUID
+	}
+	return params
+}
+
+func buildFileListParams(opts FileListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SortField != "" {
+		params["sort_field"] = opts.SortField
+	}
+	if opts.SortDir != "" {
+		params["sort_dir"] = opts.SortDir
+	}
+	if opts.Type != "" {
+		params["type"] = opts.Type
+	}
+	if opts.Result != "" {
+		params["result"] = opts.Result
+	}
+	if opts.QueryPath != "" {
+		params["query_path"] = opts.QueryPath
+	}
+	return params
+}
+
+func buildLabelListParams(opts LabelListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	return params
+}
+
+func buildViolationListParams(opts ViolationListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	return params
+}
+
+func buildGroupListParams(opts GroupListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SortField != "" {
+		params["sort_field"] = opts.SortField
+	}
+	if opts.SortDir != "" {
+		params["sort_dir"] = opts.SortDir
+	}
+	if opts.SearchQuery != "" {
+		params["search_query"] = opts.SearchQuery
+	}
+	return params
+}
+
+func buildRuleInstanceListParams(opts RuleInstanceListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SecurityRuleUUID != "" {
+		params["security_rule_uuid"] = opts.SecurityRuleUUID
+	}
+	if opts.State != "" {
+		params["state"] = opts.State
+	}
+	return params
+}
+
+func buildRuleListParams(opts RuleListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.SourceType != "" {
+		params["source_type"] = opts.SourceType
+	}
+	if opts.SearchQuery != "" {
+		params["search_query"] = opts.SearchQuery
+	}
+	return params
+}

--- a/aisec/modelsecurity/client_test.go
+++ b/aisec/modelsecurity/client_test.go
@@ -1,0 +1,587 @@
+package modelsecurity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestServers creates mock token + API servers for model security tests.
+func newTestServers(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *httptest.Server) {
+	t.Helper()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("missing Bearer auth: %q", auth)
+			w.WriteHeader(401)
+			return
+		}
+		handler(w, r)
+	}))
+
+	return tokenServer, apiServer
+}
+
+func newTestClient(t *testing.T, tokenURL, dataURL, mgmtURL string) *Client {
+	t.Helper()
+	client, err := NewClient(Opts{
+		ClientID:      "test-id",
+		ClientSecret:  "test-secret",
+		TsgID:         "123",
+		DataEndpoint:  dataURL,
+		MgmtEndpoint:  mgmtURL,
+		TokenEndpoint: tokenURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestScans_Create(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/v1/scans") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(ScanBaseResponse{UUID: "scan-1", Name: "test-scan"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	scan, err := client.Scans.Create(context.Background(), ScanCreateRequest{
+		Name:       "test-scan",
+		SourceType: SourceTypeLocal,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scan.UUID != "scan-1" {
+		t.Errorf("UUID = %q", scan.UUID)
+	}
+}
+
+func TestScans_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ScanList{
+			Items:    []ScanBaseResponse{{UUID: "scan-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.List(context.Background(), ScanListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ScanBaseResponse{UUID: "scan-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	scan, err := client.Scans.Get(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scan.UUID != "scan-1" {
+		t.Errorf("UUID = %q", scan.UUID)
+	}
+}
+
+func TestScans_GetInvalidUUID(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	_, err := client.Scans.Get(context.Background(), "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+}
+
+func TestScans_GetEvaluations(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/evaluations") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(RuleEvaluationList{
+			Items:    []RuleEvaluationResponse{{UUID: "eval-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.GetEvaluations(context.Background(), "550e8400-e29b-41d4-a716-446655440000", EvaluationListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_GetFiles(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(FileList{
+			Items:    []FileResponse{{UUID: "file-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.GetFiles(context.Background(), "550e8400-e29b-41d4-a716-446655440000", FileListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_GetViolations(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ViolationList{
+			Items:    []ViolationResponse{{UUID: "viol-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.GetViolations(context.Background(), "550e8400-e29b-41d4-a716-446655440000", ViolationListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_AddLabels(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(LabelsResponse{Labels: map[string]string{"env": "prod"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.AddLabels(context.Background(), "550e8400-e29b-41d4-a716-446655440000", LabelsCreateRequest{
+		Labels: map[string]string{"env": "prod"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Labels["env"] != "prod" {
+		t.Errorf("labels = %v", resp.Labels)
+	}
+}
+
+func TestScans_SetLabels(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(LabelsResponse{Labels: map[string]string{"env": "staging"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.SetLabels(context.Background(), "550e8400-e29b-41d4-a716-446655440000", LabelsCreateRequest{
+		Labels: map[string]string{"env": "staging"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Labels["env"] != "staging" {
+		t.Errorf("labels = %v", resp.Labels)
+	}
+}
+
+func TestScans_GetLabelKeys(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(LabelKeyList{
+			Items:    []string{"env", "team"},
+			Metadata: PaginationMeta{Total: 2},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.GetLabelKeys(context.Background(), LabelListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 2 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_GetLabelValues(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(LabelValueList{
+			Items:    []string{"prod", "staging"},
+			Metadata: PaginationMeta{Total: 2},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.GetLabelValues(context.Background(), "env", LabelListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 2 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_GetEvaluation(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(RuleEvaluationResponse{UUID: "eval-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	eval, err := client.Scans.GetEvaluation(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eval.UUID != "eval-1" {
+		t.Errorf("UUID = %q", eval.UUID)
+	}
+}
+
+func TestScans_GetViolation(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ViolationResponse{UUID: "viol-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	v, err := client.Scans.GetViolation(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.UUID != "viol-1" {
+		t.Errorf("UUID = %q", v.UUID)
+	}
+}
+
+// --- Security Groups ---
+
+func TestSecurityGroups_Create(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ModelSecurityGroupResponse{UUID: "sg-1", Name: "test-group"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	sg, err := client.SecurityGroups.Create(context.Background(), ModelSecurityGroupCreateRequest{Name: "test-group"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg.UUID != "sg-1" {
+		t.Errorf("UUID = %q", sg.UUID)
+	}
+}
+
+func TestSecurityGroups_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListModelSecurityGroupsResponse{
+			Items:    []ModelSecurityGroupResponse{{UUID: "sg-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.SecurityGroups.List(context.Background(), GroupListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestSecurityGroups_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ModelSecurityGroupResponse{UUID: "sg-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	sg, err := client.SecurityGroups.Get(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg.UUID != "sg-1" {
+		t.Errorf("UUID = %q", sg.UUID)
+	}
+}
+
+func TestSecurityGroups_Update(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ModelSecurityGroupResponse{UUID: "sg-1", Name: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	sg, err := client.SecurityGroups.Update(context.Background(), "550e8400-e29b-41d4-a716-446655440000", ModelSecurityGroupUpdateRequest{Name: "updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sg.Name != "updated" {
+		t.Errorf("Name = %q", sg.Name)
+	}
+}
+
+func TestSecurityGroups_Delete(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		w.WriteHeader(204)
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	err := client.SecurityGroups.Delete(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecurityGroups_ListRuleInstances(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListModelSecurityRuleInstancesResponse{
+			Items:    []ModelSecurityRuleInstanceResponse{{UUID: "ri-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.SecurityGroups.ListRuleInstances(context.Background(), "550e8400-e29b-41d4-a716-446655440000", RuleInstanceListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestSecurityGroups_GetRuleInstance(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ModelSecurityRuleInstanceResponse{UUID: "ri-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	ri, err := client.SecurityGroups.GetRuleInstance(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ri.UUID != "ri-1" {
+		t.Errorf("UUID = %q", ri.UUID)
+	}
+}
+
+func TestSecurityGroups_UpdateRuleInstance(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ModelSecurityRuleInstanceResponse{UUID: "ri-1", State: RuleStateBlocking})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	ri, err := client.SecurityGroups.UpdateRuleInstance(context.Background(), "550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440001", ModelSecurityRuleInstanceUpdateRequest{State: RuleStateBlocking})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ri.State != RuleStateBlocking {
+		t.Errorf("State = %q", ri.State)
+	}
+}
+
+// --- Security Rules (read-only) ---
+
+func TestSecurityRules_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListModelSecurityRulesResponse{
+			Items:    []ModelSecurityRuleResponse{{UUID: "rule-1"}},
+			Metadata: PaginationMeta{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.SecurityRules.List(context.Background(), RuleListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestSecurityRules_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ModelSecurityRuleResponse{UUID: "rule-1", Name: "test-rule"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	rule, err := client.SecurityRules.Get(context.Background(), "550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule.UUID != "rule-1" {
+		t.Errorf("UUID = %q", rule.UUID)
+	}
+}
+
+// --- PyPI Auth ---
+
+func TestGetPyPIAuth(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v1/pypi/authenticate") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(PyPIAuthResponse{URL: "https://pypi.example.com", ExpiresAt: "2026-12-31"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	auth, err := client.GetPyPIAuth(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.URL != "https://pypi.example.com" {
+		t.Errorf("URL = %q", auth.URL)
+	}
+}
+
+// --- Client validation ---
+
+func TestNewClient_MissingCredentials(t *testing.T) {
+	_, err := NewClient(Opts{})
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+}
+
+func TestSubClients_AllPresent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, "https://data.example.com", "https://mgmt.example.com")
+	if client.Scans == nil {
+		t.Error("Scans is nil")
+	}
+	if client.SecurityGroups == nil {
+		t.Error("SecurityGroups is nil")
+	}
+	if client.SecurityRules == nil {
+		t.Error("SecurityRules is nil")
+	}
+}
+
+// --- Dual endpoint routing ---
+
+func TestDualEndpointRouting(t *testing.T) {
+	var dataCalled, mgmtCalled bool
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dataCalled = true
+		_ = json.NewEncoder(w).Encode(ScanList{Items: []ScanBaseResponse{}, Metadata: PaginationMeta{}})
+	}))
+	defer dataSrv.Close()
+
+	mgmtSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mgmtCalled = true
+		_ = json.NewEncoder(w).Encode(ListModelSecurityGroupsResponse{Items: []ModelSecurityGroupResponse{}, Metadata: PaginationMeta{}})
+	}))
+	defer mgmtSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, dataSrv.URL, mgmtSrv.URL)
+
+	_, _ = client.Scans.List(context.Background(), ScanListOpts{})
+	if !dataCalled {
+		t.Error("Scans.List should hit data endpoint")
+	}
+
+	_, _ = client.SecurityGroups.List(context.Background(), GroupListOpts{})
+	if !mgmtCalled {
+		t.Error("SecurityGroups.List should hit mgmt endpoint")
+	}
+}

--- a/aisec/modelsecurity/models.go
+++ b/aisec/modelsecurity/models.go
@@ -1,0 +1,397 @@
+package modelsecurity
+
+// Enums matching TS SDK model-security-enums.ts
+
+// EvalOutcome represents the outcome of a scan evaluation.
+type EvalOutcome string
+
+const (
+	EvalOutcomePending EvalOutcome = "PENDING"
+	EvalOutcomeAllowed EvalOutcome = "ALLOWED"
+	EvalOutcomeBlocked EvalOutcome = "BLOCKED"
+	EvalOutcomeError   EvalOutcome = "ERROR"
+)
+
+// RuleEvaluationResult represents a rule evaluation result.
+type RuleEvaluationResult string
+
+const (
+	RuleEvaluationResultPassed RuleEvaluationResult = "PASSED"
+	RuleEvaluationResultFailed RuleEvaluationResult = "FAILED"
+	RuleEvaluationResultError  RuleEvaluationResult = "ERROR"
+)
+
+// RuleState represents the state of a rule instance.
+type RuleState string
+
+const (
+	RuleStateDisabled RuleState = "DISABLED"
+	RuleStateAllowing RuleState = "ALLOWING"
+	RuleStateBlocking RuleState = "BLOCKING"
+)
+
+// SourceType represents the source type of a scan.
+type SourceType string
+
+const (
+	SourceTypeLocal       SourceType = "LOCAL"
+	SourceTypeHuggingFace SourceType = "HUGGING_FACE"
+	SourceTypeS3          SourceType = "S3"
+	SourceTypeGCS         SourceType = "GCS"
+	SourceTypeAzure       SourceType = "AZURE"
+	SourceTypeArtifactory SourceType = "ARTIFACTORY"
+	SourceTypeGitLab      SourceType = "GITLAB"
+	SourceTypeAll         SourceType = "ALL"
+)
+
+// ModelSecurityGroupState represents the state of a security group.
+type ModelSecurityGroupState string
+
+const (
+	ModelSecurityGroupStatePending ModelSecurityGroupState = "PENDING"
+	ModelSecurityGroupStateActive  ModelSecurityGroupState = "ACTIVE"
+)
+
+// RuleType represents the type of a security rule.
+type RuleType string
+
+const (
+	RuleTypeMetadata RuleType = "METADATA"
+	RuleTypeArtifact RuleType = "ARTIFACT"
+)
+
+// FileType represents file or directory.
+type FileType string
+
+const (
+	FileTypeDirectory FileType = "DIRECTORY"
+	FileTypeFile      FileType = "FILE"
+)
+
+// FileScanResult represents file scan result.
+type FileScanResult string
+
+const (
+	FileScanResultSkipped FileScanResult = "SKIPPED"
+	FileScanResultSuccess FileScanResult = "SUCCESS"
+	FileScanResultError   FileScanResult = "ERROR"
+	FileScanResultFailed  FileScanResult = "FAILED"
+)
+
+// ModelScanStatus represents model scan status.
+type ModelScanStatus string
+
+const (
+	ModelScanStatusScanned ModelScanStatus = "SCANNED"
+	ModelScanStatusSkipped ModelScanStatus = "SKIPPED"
+	ModelScanStatusError   ModelScanStatus = "ERROR"
+)
+
+// ScanOrigin represents the origin of a scan.
+type ScanOrigin string
+
+const (
+	ScanOriginModelSecuritySDK ScanOrigin = "MODEL_SECURITY_SDK"
+	ScanOriginHuggingFace      ScanOrigin = "HUGGING_FACE"
+)
+
+// SortDirection represents sort direction.
+type SortDirection string
+
+const (
+	SortDirectionAsc  SortDirection = "asc"
+	SortDirectionDesc SortDirection = "desc"
+)
+
+// RuleEditableFieldType represents editable field types.
+type RuleEditableFieldType string
+
+const (
+	RuleEditableFieldTypeSelect RuleEditableFieldType = "SELECT"
+	RuleEditableFieldTypeList   RuleEditableFieldType = "LIST"
+)
+
+// --- Pagination ---
+
+// PaginationMeta holds pagination metadata.
+type PaginationMeta struct {
+	Total int `json:"total"`
+	Skip  int `json:"skip"`
+	Limit int `json:"limit"`
+}
+
+// --- Scan types ---
+
+// ScanCreateRequest is the request to create a model security scan.
+type ScanCreateRequest struct {
+	Name              string            `json:"name"`
+	SourceType        SourceType        `json:"source_type"`
+	SecurityGroupUUID string            `json:"security_group_uuid,omitempty"`
+	Source            map[string]any    `json:"source,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+}
+
+// EvaluationSummary is the summary of evaluation outcomes.
+type EvaluationSummary struct {
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	Error  int `json:"error"`
+}
+
+// ScanBaseResponse is the base scan response.
+type ScanBaseResponse struct {
+	UUID              string             `json:"uuid"`
+	Name              string             `json:"name"`
+	SourceType        SourceType         `json:"source_type,omitempty"`
+	SecurityGroupUUID string             `json:"security_group_uuid,omitempty"`
+	EvalOutcome       EvalOutcome        `json:"eval_outcome,omitempty"`
+	EvalSummary       *EvaluationSummary `json:"eval_summary,omitempty"`
+	Labels            map[string]string  `json:"labels,omitempty"`
+	CreatedAt         string             `json:"created_at,omitempty"`
+	UpdatedAt         string             `json:"updated_at,omitempty"`
+}
+
+// ScanList is the paginated list of scans.
+type ScanList struct {
+	Items    []ScanBaseResponse `json:"items"`
+	Metadata PaginationMeta     `json:"metadata"`
+}
+
+// --- Rule Evaluation types ---
+
+// RuleEvaluationResponse represents a single rule evaluation.
+type RuleEvaluationResponse struct {
+	UUID             string               `json:"uuid"`
+	ScanUUID         string               `json:"scan_uuid,omitempty"`
+	RuleInstanceUUID string               `json:"rule_instance_uuid,omitempty"`
+	RuleName         string               `json:"rule_name,omitempty"`
+	Result           RuleEvaluationResult `json:"result,omitempty"`
+	Details          map[string]any       `json:"details,omitempty"`
+	CreatedAt        string               `json:"created_at,omitempty"`
+}
+
+// RuleEvaluationList is the paginated list of rule evaluations.
+type RuleEvaluationList struct {
+	Items    []RuleEvaluationResponse `json:"items"`
+	Metadata PaginationMeta           `json:"metadata"`
+}
+
+// --- File types ---
+
+// FileResponse represents a file in a scan.
+type FileResponse struct {
+	UUID    string         `json:"uuid"`
+	Path    string         `json:"path,omitempty"`
+	Type    FileType       `json:"type,omitempty"`
+	Result  FileScanResult `json:"result,omitempty"`
+	Size    int64          `json:"size,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// FileList is the paginated list of files.
+type FileList struct {
+	Items    []FileResponse `json:"items"`
+	Metadata PaginationMeta `json:"metadata"`
+}
+
+// --- Violation types ---
+
+// ViolationResponse represents a rule violation.
+type ViolationResponse struct {
+	UUID      string         `json:"uuid"`
+	ScanUUID  string         `json:"scan_uuid,omitempty"`
+	RuleName  string         `json:"rule_name,omitempty"`
+	Details   map[string]any `json:"details,omitempty"`
+	CreatedAt string         `json:"created_at,omitempty"`
+}
+
+// ViolationList is the paginated list of violations.
+type ViolationList struct {
+	Items    []ViolationResponse `json:"items"`
+	Metadata PaginationMeta      `json:"metadata"`
+}
+
+// --- Label types ---
+
+// LabelsCreateRequest is the request to add/set labels.
+type LabelsCreateRequest struct {
+	Labels map[string]string `json:"labels"`
+}
+
+// LabelsResponse is the response from label operations.
+type LabelsResponse struct {
+	Labels map[string]string `json:"labels"`
+}
+
+// LabelKeyList is the paginated list of label keys.
+type LabelKeyList struct {
+	Items    []string       `json:"items"`
+	Metadata PaginationMeta `json:"metadata"`
+}
+
+// LabelValueList is the paginated list of label values.
+type LabelValueList struct {
+	Items    []string       `json:"items"`
+	Metadata PaginationMeta `json:"metadata"`
+}
+
+// --- Security Group types ---
+
+// ModelSecurityGroupCreateRequest is the request to create a security group.
+type ModelSecurityGroupCreateRequest struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description,omitempty"`
+	SourceType  SourceType `json:"source_type,omitempty"`
+}
+
+// ModelSecurityGroupUpdateRequest is the request to update a security group.
+type ModelSecurityGroupUpdateRequest struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// ModelSecurityGroupResponse is a security group.
+type ModelSecurityGroupResponse struct {
+	UUID        string                  `json:"uuid"`
+	Name        string                  `json:"name,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	SourceType  SourceType              `json:"source_type,omitempty"`
+	State       ModelSecurityGroupState `json:"state,omitempty"`
+	CreatedAt   string                  `json:"created_at,omitempty"`
+	UpdatedAt   string                  `json:"updated_at,omitempty"`
+}
+
+// ListModelSecurityGroupsResponse is the paginated list of security groups.
+type ListModelSecurityGroupsResponse struct {
+	Items    []ModelSecurityGroupResponse `json:"items"`
+	Metadata PaginationMeta               `json:"metadata"`
+}
+
+// --- Rule Instance types ---
+
+// ModelSecurityRuleInstanceUpdateRequest is the request to update a rule instance.
+type ModelSecurityRuleInstanceUpdateRequest struct {
+	State  RuleState      `json:"state,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+// ModelSecurityRuleInstanceResponse is a rule instance within a security group.
+type ModelSecurityRuleInstanceResponse struct {
+	UUID             string         `json:"uuid"`
+	SecurityRuleUUID string         `json:"security_rule_uuid,omitempty"`
+	State            RuleState      `json:"state,omitempty"`
+	Config           map[string]any `json:"config,omitempty"`
+	RuleName         string         `json:"rule_name,omitempty"`
+	CreatedAt        string         `json:"created_at,omitempty"`
+	UpdatedAt        string         `json:"updated_at,omitempty"`
+}
+
+// ListModelSecurityRuleInstancesResponse is the paginated list of rule instances.
+type ListModelSecurityRuleInstancesResponse struct {
+	Items    []ModelSecurityRuleInstanceResponse `json:"items"`
+	Metadata PaginationMeta                      `json:"metadata"`
+}
+
+// --- Security Rule types ---
+
+// ModelSecurityRuleResponse is a security rule (read-only).
+type ModelSecurityRuleResponse struct {
+	UUID        string     `json:"uuid"`
+	Name        string     `json:"name,omitempty"`
+	Description string     `json:"description,omitempty"`
+	SourceType  SourceType `json:"source_type,omitempty"`
+	RuleType    RuleType   `json:"rule_type,omitempty"`
+	CreatedAt   string     `json:"created_at,omitempty"`
+}
+
+// ListModelSecurityRulesResponse is the paginated list of security rules.
+type ListModelSecurityRulesResponse struct {
+	Items    []ModelSecurityRuleResponse `json:"items"`
+	Metadata PaginationMeta              `json:"metadata"`
+}
+
+// --- PyPI Auth ---
+
+// PyPIAuthResponse is the PyPI authentication response.
+type PyPIAuthResponse struct {
+	URL       string `json:"url,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// --- List Options ---
+
+// ScanListOpts are options for listing scans.
+type ScanListOpts struct {
+	Skip              int
+	Limit             int
+	SortBy            string
+	SortOrder         string
+	SearchQuery       string
+	EvalOutcomes      []string
+	SourceTypes       []string
+	SecurityGroupUUID string
+	StartTime         string
+	EndTime           string
+	LabelsQuery       string
+}
+
+// EvaluationListOpts are options for listing evaluations.
+type EvaluationListOpts struct {
+	Skip             int
+	Limit            int
+	SortField        string
+	SortOrder        string
+	Result           string
+	RuleInstanceUUID string
+}
+
+// FileListOpts are options for listing files.
+type FileListOpts struct {
+	Skip      int
+	Limit     int
+	SortField string
+	SortDir   string
+	Type      string
+	Result    string
+	QueryPath string
+}
+
+// LabelListOpts are options for listing label keys/values.
+type LabelListOpts struct {
+	Skip   int
+	Limit  int
+	Search string
+}
+
+// ViolationListOpts are options for listing violations.
+type ViolationListOpts struct {
+	Skip  int
+	Limit int
+}
+
+// GroupListOpts are options for listing security groups.
+type GroupListOpts struct {
+	Skip         int
+	Limit        int
+	SortField    string
+	SortDir      string
+	SourceTypes  []string
+	SearchQuery  string
+	EnabledRules []string
+}
+
+// RuleInstanceListOpts are options for listing rule instances.
+type RuleInstanceListOpts struct {
+	Skip             int
+	Limit            int
+	SecurityRuleUUID string
+	State            string
+}
+
+// RuleListOpts are options for listing security rules.
+type RuleListOpts struct {
+	Skip        int
+	Limit       int
+	SourceType  string
+	SearchQuery string
+}


### PR DESCRIPTION
## Summary
- Implements Model Security API with dual-endpoint routing (data plane for scans, mgmt plane for groups/rules)
- 3 sub-clients: Scans (15 methods), SecurityGroups (8 methods incl. nested rule instances), SecurityRules (2 methods)
- GetPyPIAuth convenience method on top-level client
- UUID validation on all ID-based methods
- 26 test functions covering all operations + dual endpoint routing verification

Closes #9

## Test plan
- [x] `go test -race -count=1 ./aisec/modelsecurity/` passes (26 tests)
- [ ] CI passes