### PR TITLE
feat(redteam): Red Team API client with 5 sub-clients

### DIFF
--- a/aisec/redteam/client.go
+++ b/aisec/redteam/client.go
@@ -1,0 +1,892 @@
+package redteam
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/cdot65/prisma-airs-go/aisec"
+	"github.com/cdot65/prisma-airs-go/aisec/internal"
+)
+
+// Opts are options for creating a RedTeamClient.
+type Opts struct {
+	ClientID      string
+	ClientSecret  string
+	TsgID         string
+	DataEndpoint  string
+	MgmtEndpoint  string
+	TokenEndpoint string
+	NumRetries    int
+}
+
+// Client is the Red Team API client with dual-endpoint routing.
+type Client struct {
+	Scans               *ScansClient
+	Reports             *ReportsClient
+	CustomAttackReports *CustomAttackReportsClient
+	Targets             *TargetsClient
+	CustomAttacks       *CustomAttacksClient
+
+	dataCfg *internal.OAuthServiceConfig
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+// NewClient creates a new Red Team API client.
+func NewClient(opts Opts) (*Client, error) {
+	dataEndpoint := opts.DataEndpoint
+	if dataEndpoint == "" {
+		dataEndpoint = aisec.DefaultRedTeamDataEndpoint
+	}
+	mgmtEndpoint := opts.MgmtEndpoint
+	if mgmtEndpoint == "" {
+		mgmtEndpoint = aisec.DefaultRedTeamMgmtEndpoint
+	}
+
+	mgmtCfg, err := internal.ResolveOAuthConfig(internal.ResolveOAuthConfigOpts{
+		ClientID:          opts.ClientID,
+		ClientSecret:      opts.ClientSecret,
+		TsgID:             opts.TsgID,
+		BaseURL:           mgmtEndpoint,
+		NumRetries:        opts.NumRetries,
+		TokenEndpoint:     opts.TokenEndpoint,
+		PrimaryEnvPrefix:  "PANW_RED_TEAM",
+		FallbackEnvPrefix: "PANW_MGMT",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	dataCfg := &internal.OAuthServiceConfig{
+		BaseURL:    dataEndpoint,
+		OAuth:      mgmtCfg.OAuth,
+		NumRetries: mgmtCfg.NumRetries,
+		TsgID:      mgmtCfg.TsgID,
+	}
+
+	c := &Client{dataCfg: dataCfg, mgmtCfg: mgmtCfg}
+	c.Scans = &ScansClient{dataCfg: dataCfg}
+	c.Reports = &ReportsClient{dataCfg: dataCfg}
+	c.CustomAttackReports = &CustomAttackReportsClient{dataCfg: dataCfg}
+	c.Targets = &TargetsClient{mgmtCfg: mgmtCfg}
+	c.CustomAttacks = &CustomAttacksClient{mgmtCfg: mgmtCfg}
+
+	return c, nil
+}
+
+// --- Convenience methods ---
+
+// GetScanStatistics gets scan statistics from the data plane.
+func (c *Client) GetScanStatistics(ctx context.Context, params map[string]string) (*ScanStatisticsResponse, error) {
+	resp, err := internal.DoMgmtRequest[ScanStatisticsResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamDashboardPath + "/scan-statistics", Params: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetScoreTrend gets the score trend for a target.
+func (c *Client) GetScoreTrend(ctx context.Context, targetID string) (*ScoreTrendResponse, error) {
+	resp, err := internal.DoMgmtRequest[ScoreTrendResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamDashboardPath + "/score-trend/" + targetID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetQuota gets the quota summary.
+func (c *Client) GetQuota(ctx context.Context) (*QuotaSummary, error) {
+	resp, err := internal.DoMgmtRequest[QuotaSummary](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamQuotaPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetErrorLogs gets error logs for a job.
+func (c *Client) GetErrorLogs(ctx context.Context, jobID string, opts ListOpts) (*ErrorLogListResponse, error) {
+	resp, err := internal.DoMgmtRequest[ErrorLogListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamErrorLogPath + "/" + jobID, Params: buildListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// UpdateSentiment updates the sentiment for a job.
+func (c *Client) UpdateSentiment(ctx context.Context, req SentimentRequest) (*SentimentResponse, error) {
+	resp, err := internal.DoMgmtRequest[SentimentResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamSentimentPath, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetSentiment gets the sentiment for a job.
+func (c *Client) GetSentiment(ctx context.Context, jobID string) (*SentimentResponse, error) {
+	resp, err := internal.DoMgmtRequest[SentimentResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamSentimentPath + "/" + jobID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// GetDashboardOverview gets the dashboard overview from the mgmt plane.
+func (c *Client) GetDashboardOverview(ctx context.Context) (*DashboardOverviewResponse, error) {
+	resp, err := internal.DoMgmtRequest[DashboardOverviewResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamMgmtDashboardPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Scans Client (data plane) ---
+
+// ScansClient provides red team scan operations.
+type ScansClient struct {
+	dataCfg *internal.OAuthServiceConfig
+}
+
+func (c *ScansClient) Create(ctx context.Context, req JobCreateRequest) (*JobResponse, error) {
+	resp, err := internal.DoMgmtRequest[JobResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamScanPath, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) List(ctx context.Context, opts ScanListOpts) (*JobListResponse, error) {
+	resp, err := internal.DoMgmtRequest[JobListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamScanPath, Params: buildScanListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) Get(ctx context.Context, jobID string) (*JobResponse, error) {
+	resp, err := internal.DoMgmtRequest[JobResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamScanPath + "/" + jobID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) Abort(ctx context.Context, jobID string) (*JobAbortResponse, error) {
+	resp, err := internal.DoMgmtRequest[JobAbortResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamScanPath + "/" + jobID + "/abort",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ScansClient) GetCategories(ctx context.Context) ([]CategoryModel, error) {
+	resp, err := internal.DoMgmtRequest[[]CategoryModel](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCategoriesPath,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// --- Reports Client (data plane) ---
+
+// ReportsClient provides red team report operations.
+type ReportsClient struct {
+	dataCfg *internal.OAuthServiceConfig
+}
+
+func (c *ReportsClient) GetStaticReport(ctx context.Context, jobID string) (*StaticJobReport, error) {
+	resp, err := internal.DoMgmtRequest[StaticJobReport](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportStaticPath + "/" + jobID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetDynamicReport(ctx context.Context, jobID string) (*DynamicJobReport, error) {
+	resp, err := internal.DoMgmtRequest[DynamicJobReport](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) ListAttacks(ctx context.Context, jobID string, opts AttackListOpts) (*AttackListResponse, error) {
+	resp, err := internal.DoMgmtRequest[AttackListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportPath + "/" + jobID + "/attacks", Params: buildAttackListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetAttackDetail(ctx context.Context, jobID, attackID string) (*AttackDetailResponse, error) {
+	resp, err := internal.DoMgmtRequest[AttackDetailResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportPath + "/" + jobID + "/attacks/" + attackID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetMultiTurnAttackDetail(ctx context.Context, jobID, attackID string) (*AttackMultiTurnDetailResponse, error) {
+	resp, err := internal.DoMgmtRequest[AttackMultiTurnDetailResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportPath + "/" + jobID + "/attacks/" + attackID + "/multi-turn",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetStaticRemediation(ctx context.Context, jobID string) (*RemediationResponse, error) {
+	resp, err := internal.DoMgmtRequest[RemediationResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportStaticPath + "/" + jobID + "/remediation",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetStaticRuntimePolicy(ctx context.Context, jobID string) (*RuntimeSecurityProfileResponse, error) {
+	resp, err := internal.DoMgmtRequest[RuntimeSecurityProfileResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportStaticPath + "/" + jobID + "/runtime-security-profile",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetDynamicRemediation(ctx context.Context, jobID string) (*RemediationResponse, error) {
+	resp, err := internal.DoMgmtRequest[RemediationResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/remediation",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetDynamicRuntimePolicy(ctx context.Context, jobID string) (*RuntimeSecurityProfileResponse, error) {
+	resp, err := internal.DoMgmtRequest[RuntimeSecurityProfileResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/runtime-security-profile",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) ListGoals(ctx context.Context, jobID string, opts GoalListOpts) (*GoalListResponse, error) {
+	resp, err := internal.DoMgmtRequest[GoalListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/goals", Params: buildGoalListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) ListGoalStreams(ctx context.Context, jobID, goalID string, opts ListOpts) (*StreamListResponse, error) {
+	resp, err := internal.DoMgmtRequest[StreamListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/goals/" + goalID + "/streams", Params: buildListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *ReportsClient) GetStreamDetail(ctx context.Context, streamID string) (*StreamDetailResponse, error) {
+	resp, err := internal.DoMgmtRequest[StreamDetailResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportPath + "/streams/" + streamID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Custom Attack Reports Client (data plane) ---
+
+// CustomAttackReportsClient provides custom attack report operations.
+type CustomAttackReportsClient struct {
+	dataCfg *internal.OAuthServiceConfig
+}
+
+func (c *CustomAttackReportsClient) GetReport(ctx context.Context, jobID string) (*CustomAttackReportResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomAttackReportResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) GetPromptSets(ctx context.Context, jobID string) (*PromptSetsReportResponse, error) {
+	resp, err := internal.DoMgmtRequest[PromptSetsReportResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/prompt-sets",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) GetPromptsBySet(ctx context.Context, jobID, promptSetID string, opts PromptsBySetListOpts) ([]PromptDetailResponse, error) {
+	resp, err := internal.DoMgmtRequest[[]PromptDetailResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/prompt-sets/" + promptSetID + "/prompts",
+		Params: buildPromptsBySetListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) GetPromptDetail(ctx context.Context, jobID, promptID string) (*PromptDetailResponse, error) {
+	resp, err := internal.DoMgmtRequest[PromptDetailResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/prompts/" + promptID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) ListCustomAttacks(ctx context.Context, jobID string, opts CustomAttacksReportListOpts) (*CustomAttacksListResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomAttacksListResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/attacks",
+		Params: buildCustomAttacksReportListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) GetAttackOutputs(ctx context.Context, jobID, attackID string) ([]CustomAttackOutput, error) {
+	resp, err := internal.DoMgmtRequest[[]CustomAttackOutput](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/attacks/" + attackID + "/outputs",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (c *CustomAttackReportsClient) GetPropertyStats(ctx context.Context, jobID string) ([]PropertyStatistic, error) {
+	resp, err := internal.DoMgmtRequest[[]PropertyStatistic](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttacksReportPath + "/" + jobID + "/property-stats",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+// --- Targets Client (mgmt plane) ---
+
+// TargetsClient provides target management operations.
+type TargetsClient struct {
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+func (c *TargetsClient) Create(ctx context.Context, req TargetCreateRequest, validate bool) (*TargetResponse, error) {
+	params := map[string]string{}
+	if validate {
+		params["validate"] = "true"
+	}
+	resp, err := internal.DoMgmtRequest[TargetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamTargetPath, Body: req, Params: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) List(ctx context.Context, opts TargetListOpts) (*TargetList, error) {
+	resp, err := internal.DoMgmtRequest[TargetList](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamTargetPath, Params: buildTargetListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) Get(ctx context.Context, uuid string) (*TargetResponse, error) {
+	resp, err := internal.DoMgmtRequest[TargetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamTargetPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) Update(ctx context.Context, uuid string, req TargetUpdateRequest, validate bool) (*TargetResponse, error) {
+	params := map[string]string{}
+	if validate {
+		params["validate"] = "true"
+	}
+	resp, err := internal.DoMgmtRequest[TargetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamTargetPath + "/" + uuid, Body: req, Params: params,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) Delete(ctx context.Context, uuid string) (*BaseResponse, error) {
+	resp, err := internal.DoMgmtRequest[BaseResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodDelete, Path: aisec.RedTeamTargetPath + "/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) Probe(ctx context.Context, req TargetProbeRequest) (*TargetResponse, error) {
+	resp, err := internal.DoMgmtRequest[TargetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamTargetPath + "/probe", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) GetProfile(ctx context.Context, uuid string) (*TargetProfileResponse, error) {
+	resp, err := internal.DoMgmtRequest[TargetProfileResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamTargetPath + "/" + uuid + "/profile",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *TargetsClient) UpdateProfile(ctx context.Context, uuid string, req TargetContextUpdate) (*TargetResponse, error) {
+	resp, err := internal.DoMgmtRequest[TargetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamTargetPath + "/" + uuid + "/context", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Custom Attacks Client (mgmt plane) ---
+
+// CustomAttacksClient provides custom attack/prompt set management.
+type CustomAttacksClient struct {
+	mgmtCfg *internal.OAuthServiceConfig
+}
+
+// Prompt Set operations
+
+func (c *CustomAttacksClient) CreatePromptSet(ctx context.Context, req CustomPromptSetCreateRequest) (*CustomPromptSetResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/prompt-set", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) ListPromptSets(ctx context.Context, opts PromptSetListOpts) (*CustomPromptSetList, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetList](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set", Params: buildPromptSetListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPromptSet(ctx context.Context, uuid string) (*CustomPromptSetResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) UpdatePromptSet(ctx context.Context, uuid string, req CustomPromptSetUpdateRequest) (*CustomPromptSetResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) ArchivePromptSet(ctx context.Context, uuid string, req CustomPromptSetArchiveRequest) (*CustomPromptSetResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/archive", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPromptSetReference(ctx context.Context, uuid string) (*CustomPromptSetReference, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetReference](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/reference",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPromptSetVersionInfo(ctx context.Context, uuid string) (*CustomPromptSetVersionInfo, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetVersionInfo](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/version-info",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) ListActivePromptSets(ctx context.Context) (*CustomPromptSetListActive, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptSetListActive](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/active",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// Prompt operations
+
+func (c *CustomAttacksClient) CreatePrompt(ctx context.Context, req CustomPromptCreateRequest) (*CustomPromptResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/prompt", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) ListPrompts(ctx context.Context, promptSetUUID string, opts PromptListOpts) (*CustomPromptList, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptList](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts",
+		Params: buildPromptListParams(opts),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPrompt(ctx context.Context, promptSetUUID, promptUUID string) (*CustomPromptResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) UpdatePrompt(ctx context.Context, promptSetUUID, promptUUID string, req CustomPromptUpdateRequest) (*CustomPromptResponse, error) {
+	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID, Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) DeletePrompt(ctx context.Context, promptSetUUID, promptUUID string) (*BaseResponse, error) {
+	resp, err := internal.DoMgmtRequest[BaseResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodDelete, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// Property operations
+
+func (c *CustomAttacksClient) GetPropertyNames(ctx context.Context) (*PropertyNamesListResponse, error) {
+	resp, err := internal.DoMgmtRequest[PropertyNamesListResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/property-names",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) CreatePropertyName(ctx context.Context, req PropertyNameCreateRequest) (*BaseResponse, error) {
+	resp, err := internal.DoMgmtRequest[BaseResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/property-names", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPropertyValues(ctx context.Context, propertyName string) (*PropertyValuesResponse, error) {
+	resp, err := internal.DoMgmtRequest[PropertyValuesResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/property-values/" + propertyName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) GetPropertyValuesMultiple(ctx context.Context, propertyNames []string) (*PropertyValuesMultipleResponse, error) {
+	resp, err := internal.DoMgmtRequest[PropertyValuesMultipleResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/property-values",
+		Body: map[string][]string{"property_names": propertyNames},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+func (c *CustomAttacksClient) CreatePropertyValue(ctx context.Context, req PropertyValueCreateRequest) (*BaseResponse, error) {
+	resp, err := internal.DoMgmtRequest[BaseResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
+		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/property-values/create", Body: req,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// --- Param builders ---
+
+func buildListParams(opts ListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	return params
+}
+
+func buildScanListParams(opts ScanListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.Status != "" {
+		params["status"] = opts.Status
+	}
+	if opts.JobType != "" {
+		params["job_type"] = opts.JobType
+	}
+	if opts.TargetID != "" {
+		params["target_id"] = opts.TargetID
+	}
+	return params
+}
+
+func buildAttackListParams(opts AttackListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.Status != "" {
+		params["status"] = opts.Status
+	}
+	if opts.Severity != "" {
+		params["severity"] = opts.Severity
+	}
+	if opts.Category != "" {
+		params["category"] = opts.Category
+	}
+	if opts.SubCategory != "" {
+		params["sub_category"] = opts.SubCategory
+	}
+	if opts.AttackType != "" {
+		params["attack_type"] = opts.AttackType
+	}
+	if opts.Threat != nil {
+		params["threat"] = fmt.Sprintf("%t", *opts.Threat)
+	}
+	return params
+}
+
+func buildGoalListParams(opts GoalListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.GoalType != "" {
+		params["goal_type"] = opts.GoalType
+	}
+	if opts.Status != "" {
+		params["status"] = opts.Status
+	}
+	if opts.Count != nil {
+		params["count"] = fmt.Sprintf("%t", *opts.Count)
+	}
+	return params
+}
+
+func buildTargetListParams(opts TargetListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.TargetType != "" {
+		params["target_type"] = opts.TargetType
+	}
+	if opts.Status != "" {
+		params["status"] = opts.Status
+	}
+	return params
+}
+
+func buildPromptSetListParams(opts PromptSetListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.Status != "" {
+		params["status"] = opts.Status
+	}
+	if opts.Active != nil {
+		params["active"] = fmt.Sprintf("%t", *opts.Active)
+	}
+	if opts.Archive != nil {
+		params["archive"] = fmt.Sprintf("%t", *opts.Archive)
+	}
+	return params
+}
+
+func buildPromptListParams(opts PromptListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.Active != nil {
+		params["active"] = fmt.Sprintf("%t", *opts.Active)
+	}
+	return params
+}
+
+func buildPromptsBySetListParams(opts PromptsBySetListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.IsThreat != nil {
+		params["is_threat"] = fmt.Sprintf("%t", *opts.IsThreat)
+	}
+	return params
+}
+
+func buildCustomAttacksReportListParams(opts CustomAttacksReportListOpts) map[string]string {
+	params := map[string]string{}
+	if opts.Skip > 0 {
+		params["skip"] = fmt.Sprintf("%d", opts.Skip)
+	}
+	if opts.Limit > 0 {
+		params["limit"] = fmt.Sprintf("%d", opts.Limit)
+	}
+	if opts.Search != "" {
+		params["search"] = opts.Search
+	}
+	if opts.Threat != nil {
+		params["threat"] = fmt.Sprintf("%t", *opts.Threat)
+	}
+	if opts.PromptSetID != "" {
+		params["prompt_set_id"] = opts.PromptSetID
+	}
+	if opts.PropertyValue != "" {
+		params["property_value"] = opts.PropertyValue
+	}
+	return params
+}

--- a/aisec/redteam/client_test.go
+++ b/aisec/redteam/client_test.go
@@ -1,0 +1,572 @@
+package redteam
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestServers(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *httptest.Server) {
+	t.Helper()
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "Bearer",
+		})
+	}))
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Errorf("missing Bearer auth: %q", auth)
+			w.WriteHeader(401)
+			return
+		}
+		handler(w, r)
+	}))
+	return tokenSrv, apiSrv
+}
+
+func newTestClient(t *testing.T, tokenURL, dataURL, mgmtURL string) *Client {
+	t.Helper()
+	client, err := NewClient(Opts{
+		ClientID:      "test-id",
+		ClientSecret:  "test-secret",
+		TsgID:         "123",
+		DataEndpoint:  dataURL,
+		MgmtEndpoint:  mgmtURL,
+		TokenEndpoint: tokenURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// --- Scans ---
+
+func TestScans_Create(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(JobResponse{ID: "job-1", Name: "test-scan"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	job, err := client.Scans.Create(context.Background(), JobCreateRequest{TargetID: "t-1", JobType: JobTypeStatic})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.ID != "job-1" {
+		t.Errorf("ID = %q", job.ID)
+	}
+}
+
+func TestScans_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(JobListResponse{
+			Items:      []JobResponse{{ID: "job-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.List(context.Background(), ScanListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestScans_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(JobResponse{ID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	job, err := client.Scans.Get(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.ID != "job-1" {
+		t.Errorf("ID = %q", job.ID)
+	}
+}
+
+func TestScans_Abort(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(JobAbortResponse{Message: "aborted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Scans.Abort(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "aborted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestScans_GetCategories(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]CategoryModel{{ID: "cat-1", Name: "Security"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	cats, err := client.Scans.GetCategories(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cats) != 1 {
+		t.Errorf("categories = %d", len(cats))
+	}
+}
+
+// --- Reports ---
+
+func TestReports_GetStaticReport(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(StaticJobReport{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	rpt, err := client.Reports.GetStaticReport(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rpt.JobID != "job-1" {
+		t.Errorf("JobID = %q", rpt.JobID)
+	}
+}
+
+func TestReports_GetDynamicReport(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(DynamicJobReport{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	rpt, err := client.Reports.GetDynamicReport(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rpt.JobID != "job-1" {
+		t.Errorf("JobID = %q", rpt.JobID)
+	}
+}
+
+func TestReports_ListAttacks(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(AttackListResponse{
+			Items:      []AttackListItem{{ID: "atk-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.ListAttacks(context.Background(), "job-1", AttackListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestReports_ListGoals(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(GoalListResponse{
+			Items:      []Goal{{ID: "goal-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.ListGoals(context.Background(), "job-1", GoalListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+// --- Custom Attack Reports ---
+
+func TestCustomAttackReports_GetReport(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomAttackReportResponse{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	rpt, err := client.CustomAttackReports.GetReport(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rpt.JobID != "job-1" {
+		t.Errorf("JobID = %q", rpt.JobID)
+	}
+}
+
+// --- Targets ---
+
+func TestTargets_Create(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1", Name: "test-target"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	tgt, err := client.Targets.Create(context.Background(), TargetCreateRequest{Name: "test-target"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt.UUID != "tgt-1" {
+		t.Errorf("UUID = %q", tgt.UUID)
+	}
+}
+
+func TestTargets_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(TargetList{
+			Items:      []TargetResponse{{UUID: "tgt-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Targets.List(context.Background(), TargetListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestTargets_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	tgt, err := client.Targets.Get(context.Background(), "tgt-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt.UUID != "tgt-1" {
+		t.Errorf("UUID = %q", tgt.UUID)
+	}
+}
+
+func TestTargets_Update(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1", Name: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	tgt, err := client.Targets.Update(context.Background(), "tgt-1", TargetUpdateRequest{Name: "updated"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt.Name != "updated" {
+		t.Errorf("Name = %q", tgt.Name)
+	}
+}
+
+func TestTargets_Delete(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(BaseResponse{Message: "deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Targets.Delete(context.Background(), "tgt-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestTargets_Probe(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	tgt, err := client.Targets.Probe(context.Background(), TargetProbeRequest{UUID: "tgt-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt.UUID != "tgt-1" {
+		t.Errorf("UUID = %q", tgt.UUID)
+	}
+}
+
+func TestTargets_GetProfile(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(TargetProfileResponse{UUID: "tgt-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	prof, err := client.Targets.GetProfile(context.Background(), "tgt-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prof.UUID != "tgt-1" {
+		t.Errorf("UUID = %q", prof.UUID)
+	}
+}
+
+// --- Custom Attacks ---
+
+func TestCustomAttacks_CreatePromptSet(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "test-set"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	ps, err := client.CustomAttacks.CreatePromptSet(context.Background(), CustomPromptSetCreateRequest{Name: "test-set"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ps.UUID != "ps-1" {
+		t.Errorf("UUID = %q", ps.UUID)
+	}
+}
+
+func TestCustomAttacks_ListPromptSets(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptSetList{
+			Items:      []CustomPromptSetResponse{{UUID: "ps-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.ListPromptSets(context.Background(), PromptSetListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomAttacks_GetPropertyNames(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PropertyNamesListResponse{Items: []map[string]any{{"name": "category"}}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPropertyNames(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+// --- Convenience methods ---
+
+func TestGetScanStatistics(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ScanStatisticsResponse{Stats: map[string]any{"total": 10}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	stats, err := client.GetScanStatistics(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Stats["total"] == nil {
+		t.Error("missing stats")
+	}
+}
+
+func TestGetQuota(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(QuotaSummary{Details: map[string]any{"used": 5}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	quota, err := client.GetQuota(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quota.Details["used"] == nil {
+		t.Error("missing quota details")
+	}
+}
+
+func TestGetSentiment(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SentimentResponse{JobID: "job-1", Sentiment: "positive"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.GetSentiment(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Sentiment != "positive" {
+		t.Errorf("Sentiment = %q", resp.Sentiment)
+	}
+}
+
+func TestGetDashboardOverview(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(DashboardOverviewResponse{Overview: map[string]any{"risk": "low"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.GetDashboardOverview(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Overview["risk"] == nil {
+		t.Error("missing overview")
+	}
+}
+
+// --- Client validation ---
+
+func TestNewClient_MissingCredentials(t *testing.T) {
+	_, err := NewClient(Opts{})
+	if err == nil {
+		t.Fatal("expected error for missing credentials")
+	}
+}
+
+func TestSubClients_AllPresent(t *testing.T) {
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, "https://data.example.com", "https://mgmt.example.com")
+	if client.Scans == nil {
+		t.Error("Scans is nil")
+	}
+	if client.Reports == nil {
+		t.Error("Reports is nil")
+	}
+	if client.CustomAttackReports == nil {
+		t.Error("CustomAttackReports is nil")
+	}
+	if client.Targets == nil {
+		t.Error("Targets is nil")
+	}
+	if client.CustomAttacks == nil {
+		t.Error("CustomAttacks is nil")
+	}
+}
+
+// --- Dual endpoint routing ---
+
+func TestDualEndpointRouting(t *testing.T) {
+	var dataCalled, mgmtCalled bool
+
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "t", "expires_in": 3600})
+	}))
+	defer tokenSrv.Close()
+
+	dataSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dataCalled = true
+		_ = json.NewEncoder(w).Encode(JobListResponse{Items: []JobResponse{}, Pagination: RedTeamPagination{}})
+	}))
+	defer dataSrv.Close()
+
+	mgmtSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mgmtCalled = true
+		_ = json.NewEncoder(w).Encode(TargetList{Items: []TargetResponse{}, Pagination: RedTeamPagination{}})
+	}))
+	defer mgmtSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, dataSrv.URL, mgmtSrv.URL)
+
+	_, _ = client.Scans.List(context.Background(), ScanListOpts{})
+	if !dataCalled {
+		t.Error("Scans.List should hit data endpoint")
+	}
+
+	_, _ = client.Targets.List(context.Background(), TargetListOpts{})
+	if !mgmtCalled {
+		t.Error("Targets.List should hit mgmt endpoint")
+	}
+}

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -1,0 +1,583 @@
+package redteam
+
+// --- Enums ---
+
+// JobType represents the type of a red team job.
+type JobType string
+
+const (
+	JobTypeStatic  JobType = "STATIC"
+	JobTypeDynamic JobType = "DYNAMIC"
+	JobTypeCustom  JobType = "CUSTOM"
+)
+
+// JobStatus represents the status of a red team job.
+type JobStatus string
+
+const (
+	JobStatusInit              JobStatus = "INIT"
+	JobStatusQueued            JobStatus = "QUEUED"
+	JobStatusRunning           JobStatus = "RUNNING"
+	JobStatusCompleted         JobStatus = "COMPLETED"
+	JobStatusPartiallyComplete JobStatus = "PARTIALLY_COMPLETE"
+	JobStatusFailed            JobStatus = "FAILED"
+	JobStatusAborted           JobStatus = "ABORTED"
+)
+
+// TargetType represents the type of a target.
+type TargetType string
+
+const (
+	TargetTypeApplication TargetType = "APPLICATION"
+	TargetTypeAgent       TargetType = "AGENT"
+	TargetTypeModel       TargetType = "MODEL"
+)
+
+// TargetStatus represents the status of a target.
+type TargetStatus string
+
+const (
+	TargetStatusDraft       TargetStatus = "DRAFT"
+	TargetStatusValidating  TargetStatus = "VALIDATING"
+	TargetStatusValidated   TargetStatus = "VALIDATED"
+	TargetStatusActive      TargetStatus = "ACTIVE"
+	TargetStatusInactive    TargetStatus = "INACTIVE"
+	TargetStatusFailed      TargetStatus = "FAILED"
+	TargetStatusPendingAuth TargetStatus = "PENDING_AUTH"
+)
+
+// TargetConnectionType represents the connection type for a target.
+type TargetConnectionType string
+
+const (
+	TargetConnectionTypeDatabricks  TargetConnectionType = "DATABRICKS"
+	TargetConnectionTypeBedrock     TargetConnectionType = "BEDROCK"
+	TargetConnectionTypeOpenAI      TargetConnectionType = "OPENAI"
+	TargetConnectionTypeHuggingFace TargetConnectionType = "HUGGING_FACE"
+	TargetConnectionTypeCustom      TargetConnectionType = "CUSTOM"
+	TargetConnectionTypeRest        TargetConnectionType = "REST"
+	TargetConnectionTypeStreaming   TargetConnectionType = "STREAMING"
+)
+
+// RedTeamCategory represents a red team attack category.
+type RedTeamCategory string
+
+const (
+	RedTeamCategorySecurity   RedTeamCategory = "SECURITY"
+	RedTeamCategorySafety     RedTeamCategory = "SAFETY"
+	RedTeamCategoryCompliance RedTeamCategory = "COMPLIANCE"
+	RedTeamCategoryBrand      RedTeamCategory = "BRAND"
+)
+
+// RiskRating represents a risk rating level.
+type RiskRating string
+
+const (
+	RiskRatingLow      RiskRating = "LOW"
+	RiskRatingMedium   RiskRating = "MEDIUM"
+	RiskRatingHigh     RiskRating = "HIGH"
+	RiskRatingCritical RiskRating = "CRITICAL"
+)
+
+// ResponseMode represents the response mode.
+type ResponseMode string
+
+const (
+	ResponseModeRest      ResponseMode = "REST"
+	ResponseModeStreaming ResponseMode = "STREAMING"
+)
+
+// GoalType represents a dynamic red team goal type.
+type GoalType string
+
+const (
+	GoalTypeBase             GoalType = "BASE"
+	GoalTypeToolMisuse       GoalType = "TOOL_MISUSE"
+	GoalTypeGoalManipulation GoalType = "GOAL_MANIPULATION"
+)
+
+// --- Pagination ---
+
+// RedTeamPagination holds pagination metadata.
+type RedTeamPagination struct {
+	Total int `json:"total"`
+	Skip  int `json:"skip"`
+	Limit int `json:"limit"`
+}
+
+// --- Job / Scan types ---
+
+// JobCreateRequest is the request to create a red team scan job.
+type JobCreateRequest struct {
+	TargetID string         `json:"target_id"`
+	JobType  JobType        `json:"job_type"`
+	Name     string         `json:"name,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// JobResponse represents a red team scan job.
+type JobResponse struct {
+	ID         string         `json:"id"`
+	Name       string         `json:"name,omitempty"`
+	TargetID   string         `json:"target_id,omitempty"`
+	JobType    JobType        `json:"job_type,omitempty"`
+	Status     JobStatus      `json:"status,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	Stats      map[string]any `json:"stats,omitempty"`
+	CreatedAt  string         `json:"created_at,omitempty"`
+	UpdatedAt  string         `json:"updated_at,omitempty"`
+	FinishedAt string         `json:"finished_at,omitempty"`
+}
+
+// JobListResponse is the paginated list of jobs.
+type JobListResponse struct {
+	Items      []JobResponse     `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// JobAbortResponse is the response from aborting a job.
+type JobAbortResponse struct {
+	Message string `json:"message,omitempty"`
+	Status  string `json:"status,omitempty"`
+}
+
+// CategoryModel represents a red team attack category.
+type CategoryModel struct {
+	ID            string         `json:"id,omitempty"`
+	Name          string         `json:"name,omitempty"`
+	SubCategories []SubCategory  `json:"sub_categories,omitempty"`
+	Details       map[string]any `json:"details,omitempty"`
+}
+
+// SubCategory represents a sub-category within a category.
+type SubCategory struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// --- Report types ---
+
+// StaticJobReport represents a static scan report.
+type StaticJobReport struct {
+	JobID   string         `json:"job_id,omitempty"`
+	Stats   map[string]any `json:"stats,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// DynamicJobReport represents a dynamic scan report.
+type DynamicJobReport struct {
+	JobID   string         `json:"job_id,omitempty"`
+	Stats   map[string]any `json:"stats,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// AttackListItem represents an attack in a list.
+type AttackListItem struct {
+	ID       string         `json:"id,omitempty"`
+	Category string         `json:"category,omitempty"`
+	Severity string         `json:"severity,omitempty"`
+	Status   string         `json:"status,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// AttackListResponse is the paginated list of attacks.
+type AttackListResponse struct {
+	Items      []AttackListItem  `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// AttackDetailResponse represents detailed attack information.
+type AttackDetailResponse struct {
+	ID       string         `json:"id,omitempty"`
+	Category string         `json:"category,omitempty"`
+	Severity string         `json:"severity,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// AttackMultiTurnDetailResponse represents multi-turn attack detail.
+type AttackMultiTurnDetailResponse struct {
+	ID       string         `json:"id,omitempty"`
+	Category string         `json:"category,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// RemediationResponse is the remediation advice response.
+type RemediationResponse struct {
+	JobID   string         `json:"job_id,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// RuntimeSecurityProfileResponse is the runtime security profile.
+type RuntimeSecurityProfileResponse struct {
+	JobID    string         `json:"job_id,omitempty"`
+	Policies map[string]any `json:"policies,omitempty"`
+}
+
+// GoalListResponse is the paginated list of goals.
+type GoalListResponse struct {
+	Items      []Goal            `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// Goal represents a dynamic red team goal.
+type Goal struct {
+	ID       string         `json:"id,omitempty"`
+	GoalType GoalType       `json:"goal_type,omitempty"`
+	Status   string         `json:"status,omitempty"`
+	Details  map[string]any `json:"details,omitempty"`
+}
+
+// StreamListResponse is the paginated list of streams.
+type StreamListResponse struct {
+	Items      []map[string]any  `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// StreamDetailResponse is the detail of a single stream.
+type StreamDetailResponse struct {
+	ID      string         `json:"id,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// --- Custom Attack Report types ---
+
+// CustomAttackReportResponse is the custom attack report.
+type CustomAttackReportResponse struct {
+	JobID   string         `json:"job_id,omitempty"`
+	Stats   map[string]any `json:"stats,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// PromptSetsReportResponse is the prompt sets report.
+type PromptSetsReportResponse struct {
+	Items []map[string]any `json:"items"`
+}
+
+// PromptDetailResponse is the detail of a single prompt.
+type PromptDetailResponse struct {
+	ID      string         `json:"id,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// CustomAttacksListResponse is the paginated list of custom attacks in a report.
+type CustomAttacksListResponse struct {
+	Items      []map[string]any  `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// CustomAttackOutput represents a custom attack output.
+type CustomAttackOutput struct {
+	ID      string         `json:"id,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// PropertyStatistic represents property statistics.
+type PropertyStatistic struct {
+	PropertyName string           `json:"property_name,omitempty"`
+	Values       []map[string]any `json:"values,omitempty"`
+}
+
+// --- Target types ---
+
+// TargetCreateRequest is the request to create a target.
+type TargetCreateRequest struct {
+	Name             string               `json:"name"`
+	Description      string               `json:"description,omitempty"`
+	TargetType       TargetType           `json:"target_type,omitempty"`
+	ConnectionType   TargetConnectionType `json:"connection_type,omitempty"`
+	ConnectionParams map[string]any       `json:"connection_params,omitempty"`
+	Background       map[string]any       `json:"background,omitempty"`
+	Context          map[string]any       `json:"context,omitempty"`
+	Metadata         map[string]any       `json:"metadata,omitempty"`
+}
+
+// TargetUpdateRequest is the request to update a target.
+type TargetUpdateRequest struct {
+	Name             string               `json:"name,omitempty"`
+	Description      string               `json:"description,omitempty"`
+	TargetType       TargetType           `json:"target_type,omitempty"`
+	ConnectionType   TargetConnectionType `json:"connection_type,omitempty"`
+	ConnectionParams map[string]any       `json:"connection_params,omitempty"`
+	Background       map[string]any       `json:"background,omitempty"`
+	Context          map[string]any       `json:"context,omitempty"`
+	Metadata         map[string]any       `json:"metadata,omitempty"`
+}
+
+// TargetContextUpdate is the request to update a target's context.
+type TargetContextUpdate struct {
+	Background map[string]any `json:"background,omitempty"`
+	Context    map[string]any `json:"context,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// TargetResponse represents a target.
+type TargetResponse struct {
+	UUID             string               `json:"uuid"`
+	Name             string               `json:"name,omitempty"`
+	Description      string               `json:"description,omitempty"`
+	TargetType       TargetType           `json:"target_type,omitempty"`
+	Status           TargetStatus         `json:"status,omitempty"`
+	ConnectionType   TargetConnectionType `json:"connection_type,omitempty"`
+	ConnectionParams map[string]any       `json:"connection_params,omitempty"`
+	CreatedAt        string               `json:"created_at,omitempty"`
+	UpdatedAt        string               `json:"updated_at,omitempty"`
+}
+
+// TargetList is the paginated list of targets.
+type TargetList struct {
+	Items      []TargetResponse  `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// TargetProbeRequest is the request to probe a target.
+type TargetProbeRequest struct {
+	UUID string `json:"uuid"`
+}
+
+// TargetProfileResponse is the target profile.
+type TargetProfileResponse struct {
+	UUID    string         `json:"uuid,omitempty"`
+	Profile map[string]any `json:"profile,omitempty"`
+}
+
+// BaseResponse is a generic base response.
+type BaseResponse struct {
+	Message string `json:"message,omitempty"`
+}
+
+// --- Custom Attack types ---
+
+// CustomPromptSetCreateRequest is the request to create a prompt set.
+type CustomPromptSetCreateRequest struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Properties  map[string]any `json:"properties,omitempty"`
+}
+
+// CustomPromptSetUpdateRequest is the request to update a prompt set.
+type CustomPromptSetUpdateRequest struct {
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Properties  map[string]any `json:"properties,omitempty"`
+}
+
+// CustomPromptSetArchiveRequest is the request to archive a prompt set.
+type CustomPromptSetArchiveRequest struct {
+	Archive bool `json:"archive"`
+}
+
+// CustomPromptSetResponse represents a custom prompt set.
+type CustomPromptSetResponse struct {
+	UUID        string         `json:"uuid"`
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Status      string         `json:"status,omitempty"`
+	Active      bool           `json:"active,omitempty"`
+	Archive     bool           `json:"archive,omitempty"`
+	Stats       map[string]any `json:"stats,omitempty"`
+	CreatedAt   string         `json:"created_at,omitempty"`
+	UpdatedAt   string         `json:"updated_at,omitempty"`
+}
+
+// CustomPromptSetList is the paginated list of prompt sets.
+type CustomPromptSetList struct {
+	Items      []CustomPromptSetResponse `json:"items"`
+	Pagination RedTeamPagination         `json:"pagination"`
+}
+
+// CustomPromptSetListActive is the active prompt sets list.
+type CustomPromptSetListActive struct {
+	Items []CustomPromptSetResponse `json:"items"`
+}
+
+// CustomPromptSetReference is the reference for a prompt set.
+type CustomPromptSetReference struct {
+	UUID      string         `json:"uuid,omitempty"`
+	Reference map[string]any `json:"reference,omitempty"`
+}
+
+// CustomPromptSetVersionInfo is the version info for a prompt set.
+type CustomPromptSetVersionInfo struct {
+	UUID    string         `json:"uuid,omitempty"`
+	Version map[string]any `json:"version,omitempty"`
+}
+
+// CustomPromptCreateRequest is the request to create a prompt.
+type CustomPromptCreateRequest struct {
+	PromptSetUUID string         `json:"prompt_set_uuid"`
+	Content       string         `json:"content"`
+	Properties    map[string]any `json:"properties,omitempty"`
+}
+
+// CustomPromptUpdateRequest is the request to update a prompt.
+type CustomPromptUpdateRequest struct {
+	Content    string         `json:"content,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+// CustomPromptResponse represents a custom prompt.
+type CustomPromptResponse struct {
+	UUID          string         `json:"uuid"`
+	PromptSetUUID string         `json:"prompt_set_uuid,omitempty"`
+	Content       string         `json:"content,omitempty"`
+	Properties    map[string]any `json:"properties,omitempty"`
+	Active        bool           `json:"active,omitempty"`
+	CreatedAt     string         `json:"created_at,omitempty"`
+}
+
+// CustomPromptList is the paginated list of prompts.
+type CustomPromptList struct {
+	Items      []CustomPromptResponse `json:"items"`
+	Pagination RedTeamPagination      `json:"pagination"`
+}
+
+// PropertyNamesListResponse lists property names.
+type PropertyNamesListResponse struct {
+	Items []map[string]any `json:"items"`
+}
+
+// PropertyNameCreateRequest is the request to create a property name.
+type PropertyNameCreateRequest struct {
+	Name string `json:"name"`
+}
+
+// PropertyValueCreateRequest is the request to create a property value.
+type PropertyValueCreateRequest struct {
+	PropertyName string `json:"property_name"`
+	Value        string `json:"value"`
+}
+
+// PropertyValuesResponse lists values for a property.
+type PropertyValuesResponse struct {
+	Values []string `json:"values"`
+}
+
+// PropertyValuesMultipleResponse lists values for multiple properties.
+type PropertyValuesMultipleResponse struct {
+	Properties map[string][]string `json:"properties"`
+}
+
+// --- Dashboard / Statistics types ---
+
+// ScanStatisticsResponse is the scan statistics response.
+type ScanStatisticsResponse struct {
+	Stats map[string]any `json:"stats,omitempty"`
+}
+
+// ScoreTrendResponse is the score trend response.
+type ScoreTrendResponse struct {
+	TargetID string           `json:"target_id,omitempty"`
+	Series   []map[string]any `json:"series,omitempty"`
+}
+
+// QuotaSummary is the quota summary.
+type QuotaSummary struct {
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// ErrorLogListResponse is the paginated list of error logs.
+type ErrorLogListResponse struct {
+	Items      []map[string]any  `json:"items"`
+	Pagination RedTeamPagination `json:"pagination"`
+}
+
+// SentimentRequest is the request to update sentiment.
+type SentimentRequest struct {
+	JobID     string `json:"job_id"`
+	Sentiment string `json:"sentiment"`
+}
+
+// SentimentResponse is the sentiment response.
+type SentimentResponse struct {
+	JobID     string `json:"job_id,omitempty"`
+	Sentiment string `json:"sentiment,omitempty"`
+}
+
+// DashboardOverviewResponse is the dashboard overview.
+type DashboardOverviewResponse struct {
+	Overview map[string]any `json:"overview,omitempty"`
+}
+
+// --- List Options ---
+
+// ListOpts are base pagination options.
+type ListOpts struct {
+	Skip   int
+	Limit  int
+	Search string
+}
+
+// ScanListOpts extends ListOpts with scan-specific filters.
+type ScanListOpts struct {
+	Skip     int
+	Limit    int
+	Search   string
+	Status   string
+	JobType  string
+	TargetID string
+}
+
+// AttackListOpts are options for listing attacks.
+type AttackListOpts struct {
+	Skip        int
+	Limit       int
+	Search      string
+	Status      string
+	Severity    string
+	Category    string
+	SubCategory string
+	AttackType  string
+	Threat      *bool
+}
+
+// GoalListOpts are options for listing goals.
+type GoalListOpts struct {
+	GoalType string
+	Status   string
+	Count    *bool
+}
+
+// TargetListOpts are options for listing targets.
+type TargetListOpts struct {
+	Skip       int
+	Limit      int
+	Search     string
+	TargetType string
+	Status     string
+}
+
+// PromptSetListOpts are options for listing prompt sets.
+type PromptSetListOpts struct {
+	Skip    int
+	Limit   int
+	Search  string
+	Status  string
+	Active  *bool
+	Archive *bool
+}
+
+// PromptListOpts are options for listing prompts.
+type PromptListOpts struct {
+	Skip   int
+	Limit  int
+	Search string
+	Active *bool
+}
+
+// PromptsBySetListOpts are options for listing prompts by set.
+type PromptsBySetListOpts struct {
+	Skip     int
+	Limit    int
+	Search   string
+	IsThreat *bool
+}
+
+// CustomAttacksReportListOpts are options for listing custom attacks in a report.
+type CustomAttacksReportListOpts struct {
+	Skip          int
+	Limit         int
+	Search        string
+	Threat        *bool
+	PromptSetID   string
+	PropertyValue string
+}


### PR DESCRIPTION
## Summary
- Implements Red Team API with dual-endpoint routing (data plane for scans/reports, mgmt plane for targets/custom-attacks)
- 5 sub-clients: Scans (5 methods), Reports (12 methods), CustomAttackReports (7 methods), Targets (8 methods), CustomAttacks (20 methods)
- 7 convenience methods on top-level client
- All enums match TS SDK values
- 30 test functions covering all sub-clients + dual endpoint routing

Closes #10

## Test plan
- [x] `go test -race -count=1 ./aisec/redteam/` passes (30 tests)
- [x] `go test -race -count=1 ./...` all pass
- [ ] CI passes