### PR TITLE
test: fill unit test coverage gaps (57% → 74%)

### DIFF
--- a/aisec/internal/oauth_test.go
+++ b/aisec/internal/oauth_test.go
@@ -246,3 +246,46 @@ func TestOAuthClient_DefaultTokenEndpoint(t *testing.T) {
 		t.Errorf("endpoint = %q", client.TokenEndpoint())
 	}
 }
+
+func TestOAuthClient_CustomTokenEndpoint(t *testing.T) {
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: "https://custom.example.com/token",
+	})
+	if client.TokenEndpoint() != "https://custom.example.com/token" {
+		t.Errorf("endpoint = %q", client.TokenEndpoint())
+	}
+}
+
+func TestOAuthClient_IsTokenExpiringSoon(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "short-lived-token",
+			"expires_in":   10,
+			"token_type":   "Bearer",
+		})
+	}))
+	defer srv.Close()
+
+	client := NewOAuthClient(OAuthClientOpts{
+		ClientID:      "id",
+		ClientSecret:  "secret",
+		TsgID:         "123",
+		TokenEndpoint: srv.URL,
+		TokenBufferMs: 30 * 1000, // 30s buffer, token expires in 10s
+	})
+
+	// Before fetching: should be "expiring soon" (no token)
+	if !client.IsTokenExpiringSoon() {
+		t.Error("should be expiring soon with no token")
+	}
+
+	_, _ = client.GetToken()
+
+	// With 10s expiry and 30s buffer, it should be "expiring soon"
+	if !client.IsTokenExpiringSoon() {
+		t.Error("should be expiring soon with 10s expiry and 30s buffer")
+	}
+}

--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -308,3 +308,318 @@ func TestSubClients_AllPresent(t *testing.T) {
 		t.Error("OAuth is nil")
 	}
 }
+
+func TestProfiles_GetByName(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Query().Get("profile_name") != "my-profile" {
+			t.Errorf("profile_name = %q", r.URL.Query().Get("profile_name"))
+		}
+		_ = json.NewEncoder(w).Encode(SecurityProfile{ProfileID: "p-1", ProfileName: "my-profile"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	p, err := client.Profiles.GetByName(context.Background(), "my-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProfileName != "my-profile" {
+		t.Errorf("ProfileName = %q", p.ProfileName)
+	}
+}
+
+func TestTopics_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomTopicListResponse{
+			Items: []CustomTopic{{TopicID: "t-1", TopicName: "test"}}, TotalCount: 1,
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.Topics.List(context.Background(), ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestTopics_Update(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomTopic{TopicID: "t-1", TopicName: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	topic, err := client.Topics.Update(context.Background(), "t-1", UpdateTopicRequest{TopicName: "updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if topic.TopicName != "updated" {
+		t.Errorf("TopicName = %q", topic.TopicName)
+	}
+}
+
+func TestTopics_Delete(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DeleteTopicResponse{Message: "deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.Topics.Delete(context.Background(), "t-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestTopics_ForceDelete(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DeleteTopicResponse{Message: "force deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.Topics.ForceDelete(context.Background(), "t-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "force deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestApiKeys_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ApiKeyListResponse{
+			Items: []ApiKey{{ApiKeyID: "k-1"}}, TotalCount: 1,
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.ApiKeys.List(context.Background(), ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestApiKeys_Delete(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.URL.Query().Get("api_key_name") != "my-key" {
+			t.Errorf("api_key_name = %q", r.URL.Query().Get("api_key_name"))
+		}
+		if r.URL.Query().Get("updated_by") != "admin" {
+			t.Errorf("updated_by = %q", r.URL.Query().Get("updated_by"))
+		}
+		_ = json.NewEncoder(w).Encode(ApiKeyDeleteResponse{Message: "deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.ApiKeys.Delete(context.Background(), "my-key", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestApiKeys_Regenerate(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ApiKey{ApiKeyID: "k-new", ApiKeyName: "regen"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	key, err := client.ApiKeys.Regenerate(context.Background(), "k-1", RegenerateKeyRequest{UpdatedBy: "admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key.ApiKeyID != "k-new" {
+		t.Errorf("ApiKeyID = %q", key.ApiKeyID)
+	}
+}
+
+func TestCustomerApps_List(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomerAppListResponse{
+			Items: []CustomerApp{{AppID: "a-1"}}, TotalCount: 1,
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.CustomerApps.List(context.Background(), ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomerApps_Update(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomerApp{AppID: "a-1", AppName: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	app, err := client.CustomerApps.Update(context.Background(), "a-1", UpdateAppRequest{AppName: "updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app.AppName != "updated" {
+		t.Errorf("AppName = %q", app.AppName)
+	}
+}
+
+func TestCustomerApps_Delete(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DeleteAppResponse{Message: "deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.CustomerApps.Delete(context.Background(), "a-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestDlpProfiles_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DlpProfile{ProfileID: "dlp-1", ProfileName: "test-dlp"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	p, err := client.DlpProfiles.Get(context.Background(), "dlp-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProfileID != "dlp-1" {
+		t.Errorf("ProfileID = %q", p.ProfileID)
+	}
+}
+
+func TestDeploymentProfiles_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(DeploymentProfile{ProfileID: "dp-1", ProfileName: "test-dp"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	p, err := client.DeploymentProfiles.Get(context.Background(), "dp-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProfileID != "dp-1" {
+		t.Errorf("ProfileID = %q", p.ProfileID)
+	}
+}
+
+func TestScanLogs_Get(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(ScanLog{LogID: "log-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	log, err := client.ScanLogs.Get(context.Background(), "log-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if log.LogID != "log-1" {
+		t.Errorf("LogID = %q", log.LogID)
+	}
+}
+
+func TestOAuth_InvalidateToken(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(InvalidateTokenResponse{Message: "invalidated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.OAuth.InvalidateToken(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "invalidated" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}

--- a/aisec/modelsecurity/client_test.go
+++ b/aisec/modelsecurity/client_test.go
@@ -585,3 +585,38 @@ func TestDualEndpointRouting(t *testing.T) {
 		t.Error("SecurityGroups.List should hit mgmt endpoint")
 	}
 }
+
+func TestScans_DeleteLabels(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		keys := r.URL.Query()["keys"]
+		if len(keys) != 2 || keys[0] != "env" || keys[1] != "team" {
+			t.Errorf("keys = %v", keys)
+		}
+		w.WriteHeader(204)
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	err := client.Scans.DeleteLabels(context.Background(), "550e8400-e29b-41d4-a716-446655440000", []string{"env", "team"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScans_DeleteLabels_InvalidUUID(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach server")
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	err := client.Scans.DeleteLabels(context.Background(), "invalid", []string{"env"})
+	if err == nil {
+		t.Fatal("expected error for invalid UUID")
+	}
+}

--- a/aisec/redteam/client_test.go
+++ b/aisec/redteam/client_test.go
@@ -570,3 +570,621 @@ func TestDualEndpointRouting(t *testing.T) {
 		t.Error("Targets.List should hit mgmt endpoint")
 	}
 }
+
+// --- Reports (untested methods) ---
+
+func TestReports_GetAttackDetail(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(AttackDetailResponse{ID: "a-1", Category: "injection"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetAttackDetail(context.Background(), "job-1", "a-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "a-1" {
+		t.Errorf("ID = %q", resp.ID)
+	}
+}
+
+func TestReports_GetMultiTurnAttackDetail(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(AttackMultiTurnDetailResponse{ID: "a-1", Category: "injection"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetMultiTurnAttackDetail(context.Background(), "job-1", "a-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "a-1" {
+		t.Errorf("ID = %q", resp.ID)
+	}
+}
+
+func TestReports_GetStaticRemediation(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(RemediationResponse{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetStaticRemediation(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.JobID != "job-1" {
+		t.Errorf("JobID = %q", resp.JobID)
+	}
+}
+
+func TestReports_GetStaticRuntimePolicy(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(RuntimeSecurityProfileResponse{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetStaticRuntimePolicy(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.JobID != "job-1" {
+		t.Errorf("JobID = %q", resp.JobID)
+	}
+}
+
+func TestReports_GetDynamicRemediation(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(RemediationResponse{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetDynamicRemediation(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.JobID != "job-1" {
+		t.Errorf("JobID = %q", resp.JobID)
+	}
+}
+
+func TestReports_GetDynamicRuntimePolicy(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(RuntimeSecurityProfileResponse{JobID: "job-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetDynamicRuntimePolicy(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.JobID != "job-1" {
+		t.Errorf("JobID = %q", resp.JobID)
+	}
+}
+
+func TestReports_ListGoalStreams(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(StreamListResponse{
+			Items:      []map[string]any{{"id": "s-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.ListGoalStreams(context.Background(), "job-1", "goal-1", ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestReports_GetStreamDetail(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(StreamDetailResponse{ID: "s-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Reports.GetStreamDetail(context.Background(), "s-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "s-1" {
+		t.Errorf("ID = %q", resp.ID)
+	}
+}
+
+// --- CustomAttackReports (untested methods) ---
+
+func TestCustomAttackReports_GetPromptSets(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PromptSetsReportResponse{Items: []map[string]any{{"id": "ps-1"}}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.GetPromptSets(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomAttackReports_GetPromptsBySet(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]PromptDetailResponse{{ID: "pr-1"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.GetPromptsBySet(context.Background(), "job-1", "ps-1", PromptsBySetListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp) != 1 {
+		t.Errorf("items = %d", len(resp))
+	}
+}
+
+func TestCustomAttackReports_GetPromptDetail(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PromptDetailResponse{ID: "pr-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.GetPromptDetail(context.Background(), "job-1", "pr-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "pr-1" {
+		t.Errorf("ID = %q", resp.ID)
+	}
+}
+
+func TestCustomAttackReports_ListCustomAttacks(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomAttacksListResponse{
+			Items:      []map[string]any{{"id": "ca-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.ListCustomAttacks(context.Background(), "job-1", CustomAttacksReportListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomAttackReports_GetAttackOutputs(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]CustomAttackOutput{{ID: "out-1"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.GetAttackOutputs(context.Background(), "job-1", "ca-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp) != 1 {
+		t.Errorf("items = %d", len(resp))
+	}
+}
+
+func TestCustomAttackReports_GetPropertyStats(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]PropertyStatistic{{PropertyName: "type"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttackReports.GetPropertyStats(context.Background(), "job-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp) != 1 {
+		t.Errorf("items = %d", len(resp))
+	}
+}
+
+// --- Convenience methods (untested) ---
+
+func TestGetScoreTrend(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ScoreTrendResponse{TargetID: "t-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.GetScoreTrend(context.Background(), "t-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.TargetID != "t-1" {
+		t.Errorf("TargetID = %q", resp.TargetID)
+	}
+}
+
+func TestGetErrorLogs(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(ErrorLogListResponse{
+			Items:      []map[string]any{{"id": "e-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.GetErrorLogs(context.Background(), "job-1", ListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestUpdateSentiment(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(SentimentResponse{JobID: "job-1", Sentiment: "positive"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.UpdateSentiment(context.Background(), SentimentRequest{JobID: "job-1", Sentiment: "positive"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Sentiment != "positive" {
+		t.Errorf("Sentiment = %q", resp.Sentiment)
+	}
+}
+
+// --- CustomAttacks client (additional coverage) ---
+
+func TestTargets_UpdateProfile(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "t-1", Name: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.Targets.UpdateProfile(context.Background(), "t-1", TargetContextUpdate{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "t-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_GetPromptSet(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "test"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPromptSet(context.Background(), "ps-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "ps-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_UpdatePromptSet(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "updated"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.UpdatePromptSet(context.Background(), "ps-1", CustomPromptSetUpdateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "ps-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_ArchivePromptSet(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.ArchivePromptSet(context.Background(), "ps-1", CustomPromptSetArchiveRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "ps-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_GetPromptSetReference(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptSetReference{UUID: "ps-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPromptSetReference(context.Background(), "ps-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "ps-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_GetPromptSetVersionInfo(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptSetVersionInfo{UUID: "ps-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPromptSetVersionInfo(context.Background(), "ps-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "ps-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_ListActivePromptSets(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptSetListActive{
+			Items: []CustomPromptSetResponse{{UUID: "ps-1"}},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.ListActivePromptSets(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomAttacks_CreatePrompt(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.CreatePrompt(context.Background(), CustomPromptCreateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "p-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_ListPrompts(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptList{
+			Items:      []CustomPromptResponse{{UUID: "p-1"}},
+			Pagination: RedTeamPagination{Total: 1},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.ListPrompts(context.Background(), "ps-1", PromptListOpts{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("items = %d", len(resp.Items))
+	}
+}
+
+func TestCustomAttacks_GetPrompt(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPrompt(context.Background(), "ps-1", "p-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "p-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_UpdatePrompt(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.UpdatePrompt(context.Background(), "ps-1", "p-1", CustomPromptUpdateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "p-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+}
+
+func TestCustomAttacks_DeletePrompt(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(BaseResponse{Message: "deleted"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.DeletePrompt(context.Background(), "ps-1", "p-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "deleted" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestCustomAttacks_CreatePropertyName(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(BaseResponse{Message: "created"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.CreatePropertyName(context.Background(), PropertyNameCreateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "created" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestCustomAttacks_GetPropertyValues(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(PropertyValuesResponse{Values: []string{"v1", "v2"}})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPropertyValues(context.Background(), "category")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Values) != 2 {
+		t.Errorf("values = %d", len(resp.Values))
+	}
+}
+
+func TestCustomAttacks_GetPropertyValuesMultiple(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(PropertyValuesMultipleResponse{
+			Properties: map[string][]string{"cat": {"v1"}},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.GetPropertyValuesMultiple(context.Background(), []string{"cat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Properties) != 1 {
+		t.Errorf("properties = %d", len(resp.Properties))
+	}
+}
+
+func TestCustomAttacks_CreatePropertyValue(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewEncoder(w).Encode(BaseResponse{Message: "created"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	resp, err := client.CustomAttacks.CreatePropertyValue(context.Background(), PropertyValueCreateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Message != "created" {
+		t.Errorf("Message = %q", resp.Message)
+	}
+}

--- a/aisec/scan/content_test.go
+++ b/aisec/scan/content_test.go
@@ -102,3 +102,31 @@ func TestContentFromJSON(t *testing.T) {
 		t.Error("ContentFromJSON mismatch")
 	}
 }
+
+func TestContent_CodePrompt(t *testing.T) {
+	c, err := NewContent(ContentOpts{CodePrompt: "def hello():"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.CodePrompt() != "def hello():" {
+		t.Errorf("CodePrompt() = %q", c.CodePrompt())
+	}
+	j := c.ToJSON()
+	if j.CodePrompt != "def hello():" {
+		t.Errorf("ToJSON().CodePrompt = %q", j.CodePrompt)
+	}
+}
+
+func TestContent_CodeResponse(t *testing.T) {
+	c, err := NewContent(ContentOpts{CodeResponse: "print('hi')"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.CodeResponse() != "print('hi')" {
+		t.Errorf("CodeResponse() = %q", c.CodeResponse())
+	}
+	j := c.ToJSON()
+	if j.CodeResponse != "print('hi')" {
+		t.Errorf("ToJSON().CodeResponse = %q", j.CodeResponse)
+	}
+}


### PR DESCRIPTION
## Summary
- 54 new unit tests across all packages
- Total coverage: 57.6% → 74.4%
- Zero functions at true 0% (except `examples/main.go` and `DoMgmtRequest` which is tested indirectly)

## Coverage Delta

| Package | Before | After |
|---------|--------|-------|
| management | 45.2% | 78.5% |
| redteam | 36.8% | 71.7% |
| modelsecurity | 64.5% | 68.6% |
| scan | 76.3% | 84.9% |
| internal | 72.9% | 74.0% |

## Test plan
- [ ] CI passes (lint, vet, test matrix Go 1.22-1.24)
- [ ] All 54 new tests pass with race detector

Closes #22