### PR TITLE
fix(management): always include offset param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt vet lint test test-coverage build check clean
+.PHONY: fmt vet lint test test-coverage test-integration build check clean
 
 ## Format source code
 fmt:
@@ -20,6 +20,10 @@ test:
 test-coverage:
 	go test -race -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out
+
+## Run integration tests (requires .env with real credentials)
+test-integration:
+	go test -race -v -tags=integration ./...
 
 ## Build all packages
 build:

--- a/aisec/management/client.go
+++ b/aisec/management/client.go
@@ -71,9 +71,8 @@ func buildListParams(opts ListOpts) map[string]string {
 	if opts.Limit > 0 {
 		params["limit"] = fmt.Sprintf("%d", opts.Limit)
 	}
-	if opts.Offset > 0 {
-		params["offset"] = fmt.Sprintf("%d", opts.Offset)
-	}
+	// Always include offset — the API requires the query parameter even when 0.
+	params["offset"] = fmt.Sprintf("%d", opts.Offset)
 	return params
 }
 


### PR DESCRIPTION
## Summary
- Fix `buildListParams` to always include the `offset` query parameter even when 0
- The AIRS API requires offset to be present — omitting it returns a 400 error

## Test plan
- [x] Unit tests pass
- [x] Verified against live API: topics list now works with offset=0