### PR TITLE
fix(scan): align scan models with OpenAPI spec

### DIFF
--- a/aisec/scan/integration_test.go
+++ b/aisec/scan/integration_test.go
@@ -47,8 +47,35 @@ func TestIntegration_SyncScan(t *testing.T) {
 }
 
 func TestIntegration_AsyncScan(t *testing.T) {
-	// TODO: AsyncScanObject wire format is missing req_id + scan_req wrapper
-	// that the API expects (see TS SDK AsyncScanObjectSchema). Skipping until
-	// the SDK model is fixed. Track in a separate issue.
-	t.Skip("AsyncScanObject wire format needs req_id/scan_req wrapper — SDK bug")
+	testutil.LoadProjectEnv(t)
+	testutil.RequireEnv(t, "PANW_AI_SEC_API_KEY", "PANW_AI_SEC_PROFILE_NAME")
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey(os.Getenv("PANW_AI_SEC_API_KEY")))
+	scanner := NewScanner(cfg)
+
+	profileName := os.Getenv("PANW_AI_SEC_PROFILE_NAME")
+
+	objects := []AsyncScanObject{
+		{
+			ReqID: 0,
+			ScanReq: ScanRequest{
+				AiProfile: AiProfile{ProfileName: profileName},
+				Contents: []ContentInner{{
+					Prompt:   "Tell me a joke",
+					Response: "Why did the chicken cross the road? To get to the other side.",
+				}},
+			},
+		},
+	}
+
+	resp, err := scanner.AsyncScan(context.Background(), objects)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.ScanID == "" {
+		t.Error("expected non-empty ScanID")
+	}
+
+	t.Logf("AsyncScan scanID=%s reportID=%s", resp.ScanID, resp.ReportID)
 }

--- a/aisec/scan/models.go
+++ b/aisec/scan/models.go
@@ -111,16 +111,91 @@ type MaskedData struct {
 }
 
 // PatternDetection represents a detected pattern in content.
+// Locations is an array of [start, end] offset pairs.
 type PatternDetection struct {
-	Pattern string `json:"pattern,omitempty"`
-	Start   int    `json:"start,omitempty"`
-	End     int    `json:"end,omitempty"`
+	Pattern   string  `json:"pattern,omitempty"`
+	Locations [][]int `json:"locations,omitempty"`
 }
 
-// ContentError represents an error that occurred during content scanning.
+// ContentErrorType is the type of content that encountered an error.
+type ContentErrorType string
+
+const (
+	ContentErrorTypePrompt   ContentErrorType = "prompt"
+	ContentErrorTypeResponse ContentErrorType = "response"
+)
+
+// DetectionServiceName identifies a detection service.
+type DetectionServiceName string
+
+const (
+	DetectionServiceDLP            DetectionServiceName = "dlp"
+	DetectionServiceInjection      DetectionServiceName = "injection"
+	DetectionServiceURLCats        DetectionServiceName = "url_cats"
+	DetectionServiceToxicContent   DetectionServiceName = "toxic_content"
+	DetectionServiceMaliciousCode  DetectionServiceName = "malicious_code"
+	DetectionServiceAgent          DetectionServiceName = "agent"
+	DetectionServiceTopicViolation DetectionServiceName = "topic_violation"
+	DetectionServiceDBSecurity     DetectionServiceName = "db_security"
+	DetectionServiceUngrounded     DetectionServiceName = "ungrounded"
+)
+
+// ErrorStatus indicates error or timeout.
+type ErrorStatus string
+
+const (
+	ErrorStatusError   ErrorStatus = "error"
+	ErrorStatusTimeout ErrorStatus = "timeout"
+)
+
+// ContentError represents an error during content scanning.
 type ContentError struct {
-	Type   string `json:"type,omitempty"`
-	Status string `json:"status,omitempty"`
+	ContentType ContentErrorType     `json:"content_type,omitempty"`
+	Feature     DetectionServiceName `json:"feature,omitempty"`
+	Status      ErrorStatus          `json:"status,omitempty"`
+}
+
+// ToolDetectionFlags holds boolean detection flags per service.
+type ToolDetectionFlags struct {
+	Injection      bool `json:"injection,omitempty"`
+	URLCats        bool `json:"url_cats,omitempty"`
+	DLP            bool `json:"dlp,omitempty"`
+	DBSecurity     bool `json:"db_security,omitempty"`
+	ToxicContent   bool `json:"toxic_content,omitempty"`
+	MaliciousCode  bool `json:"malicious_code,omitempty"`
+	Agent          bool `json:"agent,omitempty"`
+	TopicViolation bool `json:"topic_violation,omitempty"`
+}
+
+// TopicGuardRails holds topic guardrail details.
+type TopicGuardRails struct {
+	AllowedTopics []string `json:"allowed_topics,omitempty"`
+	BlockedTopics []string `json:"blocked_topics,omitempty"`
+}
+
+// ToolDetectionDetails holds additional detection details.
+type ToolDetectionDetails struct {
+	TopicGuardrailsDetails *TopicGuardRails `json:"topic_guardrails_details,omitempty"`
+}
+
+// ToolDetectionEntry is a single detection entry for tool I/O.
+type ToolDetectionEntry struct {
+	ToolInvoked string                `json:"tool_invoked,omitempty"`
+	Detections  *ToolDetectionFlags   `json:"detections,omitempty"`
+	Threats     []string              `json:"threats,omitempty"`
+	Details     *ToolDetectionDetails `json:"details,omitempty"`
+	MaskedData  *MaskedData           `json:"masked_data,omitempty"`
+}
+
+// IODetected holds I/O detection results as an array of detection entries.
+type IODetected struct {
+	DetectionEntries []ToolDetectionEntry `json:"detection_entries,omitempty"`
+}
+
+// ScanSummary holds aggregated detection flags and threats.
+type ScanSummary struct {
+	Detections *ToolDetectionFlags `json:"detections,omitempty"`
+	Threats    []string            `json:"threats,omitempty"`
 }
 
 // ToolDetected holds detection results for tool/agent interactions.
@@ -132,25 +207,11 @@ type ToolDetected struct {
 	OutputDetected *IODetected        `json:"output_detected,omitempty"`
 }
 
-// ScanSummary holds verdict and action.
-type ScanSummary struct {
-	Verdict string `json:"verdict,omitempty"`
-	Action  string `json:"action,omitempty"`
-}
-
-// IODetected holds I/O detection flags.
-type IODetected struct {
-	URLCats       *bool `json:"url_cats,omitempty"`
-	DLP           *bool `json:"dlp,omitempty"`
-	Injection     *bool `json:"injection,omitempty"`
-	ToxicContent  *bool `json:"toxic_content,omitempty"`
-	MaliciousCode *bool `json:"malicious_code,omitempty"`
-}
-
 // AsyncScanObject is a batch item for async scanning.
+// Each object wraps a ScanRequest with a unique request ID.
 type AsyncScanObject struct {
-	AiProfile AiProfile      `json:"ai_profile"`
-	Contents  []ContentInner `json:"contents"`
+	ReqID   uint32      `json:"req_id"`
+	ScanReq ScanRequest `json:"scan_req"`
 }
 
 // AsyncScanResponse is the async scan API response.
@@ -170,12 +231,106 @@ type ScanIDResult struct {
 	Result *ScanResponse `json:"result,omitempty"`
 }
 
+// DSResultMetadata holds metadata for a detection service result.
+type DSResultMetadata struct {
+	Ecosystem   string `json:"ecosystem,omitempty"`
+	Method      string `json:"method,omitempty"`
+	ServerName  string `json:"server_name,omitempty"`
+	ToolInvoked string `json:"tool_invoked,omitempty"`
+	Direction   string `json:"direction,omitempty"`
+}
+
+// UrlfEntry is a URL filter report entry.
+type UrlfEntry struct {
+	URL       string `json:"url,omitempty"`
+	RiskLevel string `json:"risk_level,omitempty"`
+	Action    string `json:"action,omitempty"`
+}
+
+// DlpReport holds DLP detection report details.
+type DlpReport struct {
+	DlpReportID       string `json:"dlp_report_id,omitempty"`
+	DlpProfileName    string `json:"dlp_profile_name,omitempty"`
+	DlpProfileID      string `json:"dlp_profile_id,omitempty"`
+	DlpProfileVersion int    `json:"dlp_profile_version,omitempty"`
+}
+
+// DbsEntry is a database security report entry.
+type DbsEntry struct {
+	SubType string `json:"sub_type,omitempty"`
+	Verdict string `json:"verdict,omitempty"`
+	Action  string `json:"action,omitempty"`
+}
+
+// TcReport holds toxic content report details.
+type TcReport struct {
+	Confidence string `json:"confidence,omitempty"`
+	Verdict    string `json:"verdict,omitempty"`
+}
+
+// McEntry is a malicious code analysis entry.
+type McEntry struct {
+	CodeType string `json:"code_type,omitempty"`
+	Verdict  string `json:"verdict,omitempty"`
+	Action   string `json:"action,omitempty"`
+}
+
+// McReport holds malicious code report details.
+type McReport struct {
+	AllCodeBlocks       []string       `json:"all_code_blocks,omitempty"`
+	CodeAnalysisByType  []McEntry      `json:"code_analysis_by_type,omitempty"`
+	Verdict             string         `json:"verdict,omitempty"`
+	MalwareScriptReport map[string]any `json:"malware_script_report,omitempty"`
+}
+
+// AgentEntry is an agent detection pattern entry.
+type AgentEntry struct {
+	Pattern string `json:"pattern,omitempty"`
+	Verdict string `json:"verdict,omitempty"`
+}
+
+// AgentReport holds agent detection report details.
+type AgentReport struct {
+	ModelVerdict   string       `json:"model_verdict,omitempty"`
+	AgentFramework string       `json:"agent_framework,omitempty"`
+	AgentPatterns  []AgentEntry `json:"agent_patterns,omitempty"`
+}
+
+// TgReport holds topic guardrails report details.
+type TgReport struct {
+	AllowedTopicList string   `json:"allowed_topic_list,omitempty"`
+	BlockedTopicList string   `json:"blocked_topic_list,omitempty"`
+	AllowedTopics    []string `json:"allowedTopics,omitempty"`
+	BlockedTopics    []string `json:"blockedTopics,omitempty"`
+}
+
+// CgReport holds contextual grounding report details.
+type CgReport struct {
+	Status      string `json:"status,omitempty"`
+	Explanation string `json:"explanation,omitempty"`
+	Category    string `json:"category,omitempty"`
+}
+
+// DSDetailResult holds detailed results from each detection service.
+type DSDetailResult struct {
+	UrlfReport            []UrlfEntry  `json:"urlf_report,omitempty"`
+	DlpReport             *DlpReport   `json:"dlp_report,omitempty"`
+	DbsReport             []DbsEntry   `json:"dbs_report,omitempty"`
+	TcReport              *TcReport    `json:"tc_report,omitempty"`
+	McReport              *McReport    `json:"mc_report,omitempty"`
+	AgentReport           *AgentReport `json:"agent_report,omitempty"`
+	TopicGuardrailsReport *TgReport    `json:"topic_guardrails_report,omitempty"`
+	CgReport              *CgReport    `json:"cg_report,omitempty"`
+}
+
 // DetectionServiceResult holds results from a single detection service.
 type DetectionServiceResult struct {
-	ServiceName string         `json:"service_name,omitempty"`
-	Verdict     string         `json:"verdict,omitempty"`
-	Action      string         `json:"action,omitempty"`
-	Details     map[string]any `json:"details,omitempty"`
+	DataType         string            `json:"data_type,omitempty"`
+	DetectionService string            `json:"detection_service,omitempty"`
+	Verdict          string            `json:"verdict,omitempty"`
+	Action           string            `json:"action,omitempty"`
+	Metadata         *DSResultMetadata `json:"metadata,omitempty"`
+	ResultDetail     *DSDetailResult   `json:"result_detail,omitempty"`
 }
 
 // ThreatScanReport is a detailed threat scan report.
@@ -202,14 +357,4 @@ const (
 	CategoryBenign    = "benign"
 	CategoryMalicious = "malicious"
 	CategoryUnknown   = "unknown"
-
-	DetectionServiceDLP            = "dlp"
-	DetectionServiceInjection      = "injection"
-	DetectionServiceURLCats        = "url_cats"
-	DetectionServiceToxicContent   = "toxic_content"
-	DetectionServiceMaliciousCode  = "malicious_code"
-	DetectionServiceAgent          = "agent"
-	DetectionServiceTopicViolation = "topic_violation"
-	DetectionServiceDBSecurity     = "db_security"
-	DetectionServiceUngrounded     = "ungrounded"
 )

--- a/aisec/scan/scanner.go
+++ b/aisec/scan/scanner.go
@@ -83,6 +83,13 @@ func (s *Scanner) AsyncScan(ctx context.Context, objects []AsyncScanObject) (*As
 		)
 	}
 
+	// Validate that each object has a ReqID set; auto-assign if zero.
+	for i := range objects {
+		if objects[i].ReqID == 0 {
+			objects[i].ReqID = uint32(i)
+		}
+	}
+
 	resp, err := internal.DoRequest[AsyncScanResponse](ctx, s.cfg, internal.RequestOptions{
 		Method: "POST",
 		Path:   aisec.AsyncScanPath,

--- a/aisec/scan/scanner_test.go
+++ b/aisec/scan/scanner_test.go
@@ -87,6 +87,66 @@ func TestScanner_AsyncScan_TooManyObjects(t *testing.T) {
 	}
 }
 
+func TestScanner_AsyncScan_WireFormat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body []map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		if len(body) != 1 {
+			t.Fatalf("expected 1 object, got %d", len(body))
+		}
+		obj := body[0]
+
+		// Verify req_id exists
+		if _, ok := obj["req_id"]; !ok {
+			t.Error("missing req_id in async scan object")
+		}
+
+		// Verify scan_req wrapper exists
+		scanReq, ok := obj["scan_req"]
+		if !ok {
+			t.Error("missing scan_req wrapper in async scan object")
+		}
+
+		// Verify scan_req contains ai_profile and contents
+		if sr, ok := scanReq.(map[string]any); ok {
+			if sr["ai_profile"] == nil {
+				t.Error("missing ai_profile in scan_req")
+			}
+			if sr["contents"] == nil {
+				t.Error("missing contents in scan_req")
+			}
+		}
+
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(AsyncScanResponse{
+			ScanID: "async-123",
+		})
+	}))
+	defer server.Close()
+
+	cfg := aisec.NewConfig(aisec.WithAPIKey("k"), aisec.WithEndpoint(server.URL))
+	scanner := NewScanner(cfg)
+
+	objects := []AsyncScanObject{
+		{
+			ReqID: 1,
+			ScanReq: ScanRequest{
+				AiProfile: AiProfile{ProfileName: "test"},
+				Contents:  []ContentInner{{Prompt: "hello"}},
+			},
+		},
+	}
+
+	resp, err := scanner.AsyncScan(context.Background(), objects)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ScanID != "async-123" {
+		t.Errorf("ScanID = %q", resp.ScanID)
+	}
+}
+
 func TestScanner_QueryByScanIDs_Valid(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ids := r.URL.Query().Get("scan_ids")
@@ -205,5 +265,232 @@ func TestModels_JSONSerialization(t *testing.T) {
 	}
 	if decoded.ScanID != "scan-1" || decoded.Category != "benign" {
 		t.Errorf("decoded = %+v", decoded)
+	}
+}
+
+func TestAsyncScanObject_JSONFormat(t *testing.T) {
+	obj := AsyncScanObject{
+		ReqID: 42,
+		ScanReq: ScanRequest{
+			AiProfile: AiProfile{ProfileName: "test-profile"},
+			Contents:  []ContentInner{{Prompt: "hello"}},
+		},
+	}
+	data, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["req_id"] == nil {
+		t.Error("missing req_id in JSON")
+	}
+	if decoded["scan_req"] == nil {
+		t.Error("missing scan_req in JSON")
+	}
+	// Should NOT have ai_profile at top level
+	if decoded["ai_profile"] != nil {
+		t.Error("ai_profile should be inside scan_req, not at top level")
+	}
+}
+
+func TestContentError_JSONFormat(t *testing.T) {
+	ce := ContentError{
+		ContentType: ContentErrorTypePrompt,
+		Feature:     DetectionServiceDLP,
+		Status:      ErrorStatusTimeout,
+	}
+	data, err := json.Marshal(ce)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["content_type"] != "prompt" {
+		t.Errorf("content_type = %v", decoded["content_type"])
+	}
+	if decoded["feature"] != "dlp" {
+		t.Errorf("feature = %v", decoded["feature"])
+	}
+	if decoded["status"] != "timeout" {
+		t.Errorf("status = %v", decoded["status"])
+	}
+}
+
+func TestPatternDetection_JSONFormat(t *testing.T) {
+	pd := PatternDetection{
+		Pattern:   "SSN",
+		Locations: [][]int{{0, 11}, {20, 31}},
+	}
+	data, err := json.Marshal(pd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["pattern"] != "SSN" {
+		t.Errorf("pattern = %v", decoded["pattern"])
+	}
+	locs, ok := decoded["locations"].([]any)
+	if !ok || len(locs) != 2 {
+		t.Fatalf("locations = %v", decoded["locations"])
+	}
+	// Verify first location pair
+	pair, ok := locs[0].([]any)
+	if !ok || len(pair) != 2 {
+		t.Errorf("first location pair = %v", locs[0])
+	}
+}
+
+func TestIODetected_JSONFormat(t *testing.T) {
+	io := IODetected{
+		DetectionEntries: []ToolDetectionEntry{
+			{
+				ToolInvoked: "get_file",
+				Detections:  &ToolDetectionFlags{DLP: true, Injection: true},
+				Threats:     []string{"credential leakage"},
+			},
+		},
+	}
+	data, err := json.Marshal(io)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, ok := decoded["detection_entries"].([]any)
+	if !ok || len(entries) != 1 {
+		t.Fatalf("detection_entries = %v", decoded["detection_entries"])
+	}
+
+	// Should NOT have flat boolean fields
+	if decoded["url_cats"] != nil || decoded["dlp"] != nil {
+		t.Error("IODetected should not have flat boolean fields")
+	}
+}
+
+func TestScanSummary_JSONFormat(t *testing.T) {
+	ss := ScanSummary{
+		Detections: &ToolDetectionFlags{DLP: true, MaliciousCode: true},
+		Threats:    []string{"credential leakage", "context poisoning"},
+	}
+	data, err := json.Marshal(ss)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["detections"] == nil {
+		t.Error("missing detections")
+	}
+	threats, ok := decoded["threats"].([]any)
+	if !ok || len(threats) != 2 {
+		t.Fatalf("threats = %v", decoded["threats"])
+	}
+	// Should NOT have verdict/action
+	if decoded["verdict"] != nil || decoded["action"] != nil {
+		t.Error("ScanSummary should not have verdict/action fields")
+	}
+}
+
+func TestDetectionServiceResult_JSONFormat(t *testing.T) {
+	dsr := DetectionServiceResult{
+		DataType:         "prompt",
+		DetectionService: "dlp",
+		Verdict:          "malicious",
+		Action:           "block",
+		Metadata: &DSResultMetadata{
+			Ecosystem: "mcp",
+			Direction: "input",
+		},
+		ResultDetail: &DSDetailResult{
+			DlpReport: &DlpReport{
+				DlpReportID:    "rpt-1",
+				DlpProfileName: "default",
+			},
+		},
+	}
+	data, err := json.Marshal(dsr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["data_type"] != "prompt" {
+		t.Errorf("data_type = %v", decoded["data_type"])
+	}
+	if decoded["detection_service"] != "dlp" {
+		t.Errorf("detection_service = %v", decoded["detection_service"])
+	}
+	if decoded["metadata"] == nil {
+		t.Error("missing metadata")
+	}
+	if decoded["result_detail"] == nil {
+		t.Error("missing result_detail")
+	}
+}
+
+func TestToolDetected_FullRoundTrip(t *testing.T) {
+	td := ToolDetected{
+		Verdict: "malicious",
+		Metadata: &ToolEventMetadata{
+			Ecosystem:   "mcp",
+			Method:      "tools/call",
+			ServerName:  "test-server",
+			ToolInvoked: "get_file",
+		},
+		Summary: &ScanSummary{
+			Detections: &ToolDetectionFlags{DLP: true},
+			Threats:    []string{"data leak"},
+		},
+		InputDetected: &IODetected{
+			DetectionEntries: []ToolDetectionEntry{
+				{ToolInvoked: "get_file", Threats: []string{"injection"}},
+			},
+		},
+	}
+
+	data, err := json.Marshal(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded ToolDetected
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.Verdict != "malicious" {
+		t.Errorf("Verdict = %q", decoded.Verdict)
+	}
+	if decoded.Summary == nil || decoded.Summary.Detections == nil || !decoded.Summary.Detections.DLP {
+		t.Error("Summary.Detections.DLP should be true")
+	}
+	if decoded.InputDetected == nil || len(decoded.InputDetected.DetectionEntries) != 1 {
+		t.Error("InputDetected should have 1 entry")
 	}
 }


### PR DESCRIPTION
## Summary
- Rewrites all scan model structs to match `ScanService_Oct2025.yaml` spec
- Fixes AsyncScanObject wire format (req_id + scan_req wrapper)
- Adds all detection sub-report types (DLP, URLF, DBS, TC, MC, Agent, TG, CG)

## Changes
- `AsyncScanObject`: `{req_id, scan_req}` wrapper instead of flat `{ai_profile, contents}`
- `IODetected`: `detection_entries` array of `ToolDetectionEntry` (was flat booleans)
- `PatternDetection`: `locations` as `[][]int` (was flat Start/End)
- `ScanSummary`: `detections` + `threats` (was verdict/action)
- `ContentError`: typed `content_type`, `feature`, `status` fields
- `DetectionServiceResult`: full spec fields with nested `DSResultMetadata` and `DSDetailResult`
- New types: `ToolDetectionEntry`, `ToolDetectionFlags`, `DSDetailResult`, `DlpReport`, `UrlfEntry`, `DbsEntry`, `TcReport`, `McReport`, `AgentReport`, `TgReport`, `CgReport`
- Unskipped `TestIntegration_AsyncScan` with correct wire format

## Testing
- 19 unit tests (7 new spec-alignment tests)
- All existing tests updated and passing
- Integration test unskipped

Closes #27