### PR TITLE
fix(redteam): align redteam package with OpenAPI specs

### DIFF
--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -175,4 +175,12 @@ const (
 	RedTeamTargetPath        = "/v1/target"
 	RedTeamCustomAttackPath  = "/v1/custom-attack"
 	RedTeamMgmtDashboardPath = "/v1/dashboard/overview"
+
+	// Custom attack prompt set sub-paths (management plane).
+	RedTeamCustomPromptSetPath        = "/v1/custom-attack/custom-prompt-set"
+	RedTeamListCustomPromptSetsPath   = "/v1/custom-attack/list-custom-prompt-sets"
+	RedTeamActiveCustomPromptSetsPath = "/v1/custom-attack/active-custom-prompt-sets"
+
+	// Report download (data plane).
+	RedTeamReportDownloadPath = "/v1/report"
 )

--- a/aisec/redteam/client.go
+++ b/aisec/redteam/client.go
@@ -1,9 +1,12 @@
 package redteam
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/cdot65/prisma-airs-go/aisec"
 	"github.com/cdot65/prisma-airs-go/aisec/internal"
@@ -277,9 +280,9 @@ func (c *ReportsClient) GetStaticRemediation(ctx context.Context, jobID string) 
 	return &resp.Data, nil
 }
 
-func (c *ReportsClient) GetStaticRuntimePolicy(ctx context.Context, jobID string) (*RuntimeSecurityProfileResponse, error) {
-	resp, err := internal.DoMgmtRequest[RuntimeSecurityProfileResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamReportStaticPath + "/" + jobID + "/runtime-security-profile",
+func (c *ReportsClient) GetStaticRuntimePolicy(ctx context.Context, jobID string) (*RuntimePolicyConfigResponse, error) {
+	resp, err := internal.DoMgmtRequest[RuntimePolicyConfigResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportStaticPath + "/" + jobID + "/runtime-policy-config",
 	})
 	if err != nil {
 		return nil, err
@@ -297,9 +300,9 @@ func (c *ReportsClient) GetDynamicRemediation(ctx context.Context, jobID string)
 	return &resp.Data, nil
 }
 
-func (c *ReportsClient) GetDynamicRuntimePolicy(ctx context.Context, jobID string) (*RuntimeSecurityProfileResponse, error) {
-	resp, err := internal.DoMgmtRequest[RuntimeSecurityProfileResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/runtime-security-profile",
+func (c *ReportsClient) GetDynamicRuntimePolicy(ctx context.Context, jobID string) (*RuntimePolicyConfigResponse, error) {
+	resp, err := internal.DoMgmtRequest[RuntimePolicyConfigResponse](ctx, c.dataCfg, internal.MgmtRequestOptions{
+		Method: http.MethodGet, Path: aisec.RedTeamReportDynamicPath + "/" + jobID + "/runtime-policy-config",
 	})
 	if err != nil {
 		return nil, err
@@ -335,6 +338,56 @@ func (c *ReportsClient) GetStreamDetail(ctx context.Context, streamID string) (*
 		return nil, err
 	}
 	return &resp.Data, nil
+}
+
+// DownloadReport downloads a report in the specified format.
+func (c *ReportsClient) DownloadReport(ctx context.Context, jobID string, format FileFormat) ([]byte, error) {
+	svcCfg := c.dataCfg
+	path := aisec.RedTeamReportDownloadPath + "/" + jobID + "/download"
+
+	u, err := url.Parse(svcCfg.BaseURL + path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %s%s: %w", svcCfg.BaseURL, path, err)
+	}
+	q := u.Query()
+	q.Set("file_format", string(format))
+	u.RawQuery = q.Encode()
+
+	resp, err := internal.ExecuteWithRetry(internal.RetryOptions{
+		MaxRetries: svcCfg.NumRetries,
+		Execute: func(attempt int) (*http.Response, error) {
+			token, tokenErr := svcCfg.OAuth.GetToken()
+			if tokenErr != nil {
+				return nil, tokenErr
+			}
+			req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if reqErr != nil {
+				return nil, reqErr
+			}
+			req.Header.Set("User-Agent", aisec.UserAgent)
+			req.Header.Set(aisec.HeaderAuthToken, aisec.Bearer+token)
+			return http.DefaultClient.Do(req)
+		},
+		OnRetryableFailure: func(resp *http.Response, attempt int) (bool, error) {
+			if resp.StatusCode == 401 || resp.StatusCode == 403 {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				svcCfg.OAuth.ClearToken()
+				return true, nil
+			}
+			return false, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, resp.Body); err != nil {
+		return nil, fmt.Errorf("failed to read report body: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 // --- Custom Attack Reports Client (data plane) ---
@@ -522,7 +575,7 @@ type CustomAttacksClient struct {
 
 func (c *CustomAttacksClient) CreatePromptSet(ctx context.Context, req CustomPromptSetCreateRequest) (*CustomPromptSetResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/prompt-set", Body: req,
+		Method: http.MethodPost, Path: aisec.RedTeamCustomPromptSetPath, Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -532,7 +585,7 @@ func (c *CustomAttacksClient) CreatePromptSet(ctx context.Context, req CustomPro
 
 func (c *CustomAttacksClient) ListPromptSets(ctx context.Context, opts PromptSetListOpts) (*CustomPromptSetList, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetList](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set", Params: buildPromptSetListParams(opts),
+		Method: http.MethodGet, Path: aisec.RedTeamListCustomPromptSetsPath, Params: buildPromptSetListParams(opts),
 	})
 	if err != nil {
 		return nil, err
@@ -542,7 +595,7 @@ func (c *CustomAttacksClient) ListPromptSets(ctx context.Context, opts PromptSet
 
 func (c *CustomAttacksClient) GetPromptSet(ctx context.Context, uuid string) (*CustomPromptSetResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid,
+		Method: http.MethodGet, Path: aisec.RedTeamCustomPromptSetPath + "/" + uuid,
 	})
 	if err != nil {
 		return nil, err
@@ -552,7 +605,7 @@ func (c *CustomAttacksClient) GetPromptSet(ctx context.Context, uuid string) (*C
 
 func (c *CustomAttacksClient) UpdatePromptSet(ctx context.Context, uuid string, req CustomPromptSetUpdateRequest) (*CustomPromptSetResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid, Body: req,
+		Method: http.MethodPut, Path: aisec.RedTeamCustomPromptSetPath + "/" + uuid, Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -562,7 +615,7 @@ func (c *CustomAttacksClient) UpdatePromptSet(ctx context.Context, uuid string, 
 
 func (c *CustomAttacksClient) ArchivePromptSet(ctx context.Context, uuid string, req CustomPromptSetArchiveRequest) (*CustomPromptSetResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/archive", Body: req,
+		Method: http.MethodPut, Path: aisec.RedTeamCustomPromptSetPath + "/" + uuid + "/archive", Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -572,7 +625,7 @@ func (c *CustomAttacksClient) ArchivePromptSet(ctx context.Context, uuid string,
 
 func (c *CustomAttacksClient) GetPromptSetReference(ctx context.Context, uuid string) (*CustomPromptSetReference, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetReference](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/reference",
+		Method: http.MethodGet, Path: aisec.RedTeamCustomPromptSetPath + "/" + uuid + "/reference",
 	})
 	if err != nil {
 		return nil, err
@@ -582,7 +635,7 @@ func (c *CustomAttacksClient) GetPromptSetReference(ctx context.Context, uuid st
 
 func (c *CustomAttacksClient) GetPromptSetVersionInfo(ctx context.Context, uuid string) (*CustomPromptSetVersionInfo, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetVersionInfo](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + uuid + "/version-info",
+		Method: http.MethodGet, Path: aisec.RedTeamCustomPromptSetPath + "/" + uuid + "/version-info",
 	})
 	if err != nil {
 		return nil, err
@@ -592,7 +645,7 @@ func (c *CustomAttacksClient) GetPromptSetVersionInfo(ctx context.Context, uuid 
 
 func (c *CustomAttacksClient) ListActivePromptSets(ctx context.Context) (*CustomPromptSetListActive, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptSetListActive](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/active",
+		Method: http.MethodGet, Path: aisec.RedTeamActiveCustomPromptSetsPath,
 	})
 	if err != nil {
 		return nil, err
@@ -604,7 +657,7 @@ func (c *CustomAttacksClient) ListActivePromptSets(ctx context.Context) (*Custom
 
 func (c *CustomAttacksClient) CreatePrompt(ctx context.Context, req CustomPromptCreateRequest) (*CustomPromptResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPost, Path: aisec.RedTeamCustomAttackPath + "/prompt", Body: req,
+		Method: http.MethodPost, Path: aisec.RedTeamCustomPromptSetPath + "/custom-prompt", Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -612,9 +665,9 @@ func (c *CustomAttacksClient) CreatePrompt(ctx context.Context, req CustomPrompt
 	return &resp.Data, nil
 }
 
-func (c *CustomAttacksClient) ListPrompts(ctx context.Context, promptSetUUID string, opts PromptListOpts) (*CustomPromptList, error) {
+func (c *CustomAttacksClient) ListPrompts(ctx context.Context, promptSetID string, opts PromptListOpts) (*CustomPromptList, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptList](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts",
+		Method: http.MethodGet, Path: aisec.RedTeamCustomPromptSetPath + "/" + promptSetID + "/list-custom-prompts",
 		Params: buildPromptListParams(opts),
 	})
 	if err != nil {
@@ -623,9 +676,9 @@ func (c *CustomAttacksClient) ListPrompts(ctx context.Context, promptSetUUID str
 	return &resp.Data, nil
 }
 
-func (c *CustomAttacksClient) GetPrompt(ctx context.Context, promptSetUUID, promptUUID string) (*CustomPromptResponse, error) {
+func (c *CustomAttacksClient) GetPrompt(ctx context.Context, promptSetID, promptID string) (*CustomPromptResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID,
+		Method: http.MethodGet, Path: aisec.RedTeamCustomPromptSetPath + "/" + promptSetID + "/custom-prompt/" + promptID,
 	})
 	if err != nil {
 		return nil, err
@@ -633,9 +686,9 @@ func (c *CustomAttacksClient) GetPrompt(ctx context.Context, promptSetUUID, prom
 	return &resp.Data, nil
 }
 
-func (c *CustomAttacksClient) UpdatePrompt(ctx context.Context, promptSetUUID, promptUUID string, req CustomPromptUpdateRequest) (*CustomPromptResponse, error) {
+func (c *CustomAttacksClient) UpdatePrompt(ctx context.Context, promptSetID, promptID string, req CustomPromptUpdateRequest) (*CustomPromptResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomPromptResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPut, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID, Body: req,
+		Method: http.MethodPut, Path: aisec.RedTeamCustomPromptSetPath + "/" + promptSetID + "/custom-prompt/" + promptID, Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -643,9 +696,9 @@ func (c *CustomAttacksClient) UpdatePrompt(ctx context.Context, promptSetUUID, p
 	return &resp.Data, nil
 }
 
-func (c *CustomAttacksClient) DeletePrompt(ctx context.Context, promptSetUUID, promptUUID string) (*BaseResponse, error) {
+func (c *CustomAttacksClient) DeletePrompt(ctx context.Context, promptSetID, promptID string) (*BaseResponse, error) {
 	resp, err := internal.DoMgmtRequest[BaseResponse](ctx, c.mgmtCfg, internal.MgmtRequestOptions{
-		Method: http.MethodDelete, Path: aisec.RedTeamCustomAttackPath + "/prompt-set/" + promptSetUUID + "/prompts/" + promptUUID,
+		Method: http.MethodDelete, Path: aisec.RedTeamCustomPromptSetPath + "/" + promptSetID + "/custom-prompt/" + promptID,
 	})
 	if err != nil {
 		return nil, err

--- a/aisec/redteam/client_test.go
+++ b/aisec/redteam/client_test.go
@@ -54,25 +54,34 @@ func TestScans_Create(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("method = %s", r.Method)
 		}
-		_ = json.NewEncoder(w).Encode(JobResponse{ID: "job-1", Name: "test-scan"})
+		var req JobCreateRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Target.UUID != "t-1" {
+			t.Errorf("target.uuid = %q", req.Target.UUID)
+		}
+		_ = json.NewEncoder(w).Encode(JobResponse{UUID: "job-1", Name: "test-scan"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
-	job, err := client.Scans.Create(context.Background(), JobCreateRequest{TargetID: "t-1", JobType: JobTypeStatic})
+	job, err := client.Scans.Create(context.Background(), JobCreateRequest{
+		Name:    "test-scan",
+		Target:  TargetJobRequest{UUID: "t-1"},
+		JobType: JobTypeStatic,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if job.ID != "job-1" {
-		t.Errorf("ID = %q", job.ID)
+	if job.UUID != "job-1" {
+		t.Errorf("UUID = %q", job.UUID)
 	}
 }
 
 func TestScans_List(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(JobListResponse{
-			Items:      []JobResponse{{ID: "job-1"}},
+			Items:      []JobResponse{{UUID: "job-1"}},
 			Pagination: RedTeamPagination{Total: 1},
 		})
 	})
@@ -91,7 +100,7 @@ func TestScans_List(t *testing.T) {
 
 func TestScans_Get(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(JobResponse{ID: "job-1"})
+		_ = json.NewEncoder(w).Encode(JobResponse{UUID: "job-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -101,8 +110,8 @@ func TestScans_Get(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if job.ID != "job-1" {
-		t.Errorf("ID = %q", job.ID)
+	if job.UUID != "job-1" {
+		t.Errorf("UUID = %q", job.UUID)
 	}
 }
 
@@ -342,13 +351,73 @@ func TestTargets_Probe(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("method = %s", r.Method)
 		}
+		var req TargetProbeRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "probe-target" {
+			t.Errorf("Name = %q", req.Name)
+		}
 		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
-	tgt, err := client.Targets.Probe(context.Background(), TargetProbeRequest{UUID: "tgt-1"})
+	tgt, err := client.Targets.Probe(context.Background(), TargetProbeRequest{Name: "probe-target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt.UUID != "tgt-1" {
+		t.Errorf("UUID = %q", tgt.UUID)
+	}
+}
+
+func TestTargets_Probe_AllFields(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		var req TargetProbeRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.Name != "full-probe" {
+			t.Errorf("Name = %q", req.Name)
+		}
+		if req.TargetType != TargetTypeApplication {
+			t.Errorf("TargetType = %q", req.TargetType)
+		}
+		if req.ConnectionType != TargetConnectionTypeRest {
+			t.Errorf("ConnectionType = %q", req.ConnectionType)
+		}
+		if req.APIEndpointType != APIEndpointTypeChatCompletion {
+			t.Errorf("APIEndpointType = %q", req.APIEndpointType)
+		}
+		if req.ResponseMode != ResponseModeRest {
+			t.Errorf("ResponseMode = %q", req.ResponseMode)
+		}
+		if req.SessionSupported == nil || *req.SessionSupported != true {
+			t.Errorf("SessionSupported = %v", req.SessionSupported)
+		}
+		if req.UUID != "existing-uuid" {
+			t.Errorf("UUID = %q", req.UUID)
+		}
+		if len(req.ProbeFields) != 1 || req.ProbeFields[0] != "field1" {
+			t.Errorf("ProbeFields = %v", req.ProbeFields)
+		}
+		_ = json.NewEncoder(w).Encode(TargetResponse{UUID: "tgt-1"})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	sessionSupported := true
+	tgt, err := client.Targets.Probe(context.Background(), TargetProbeRequest{
+		Name:             "full-probe",
+		Description:      "A full probe",
+		TargetType:       TargetTypeApplication,
+		ConnectionType:   TargetConnectionTypeRest,
+		APIEndpointType:  APIEndpointTypeChatCompletion,
+		ResponseMode:     ResponseModeRest,
+		SessionSupported: &sessionSupported,
+		ConnectionParams: map[string]any{"url": "https://example.com"},
+		UUID:             "existing-uuid",
+		ProbeFields:      []string{"field1"},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,6 +450,9 @@ func TestCustomAttacks_CreatePromptSet(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("method = %s", r.Method)
 		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "test-set"})
 	})
 	defer tokenSrv.Close()
@@ -398,6 +470,9 @@ func TestCustomAttacks_CreatePromptSet(t *testing.T) {
 
 func TestCustomAttacks_ListPromptSets(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/list-custom-prompt-sets") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetList{
 			Items:      []CustomPromptSetResponse{{UUID: "ps-1"}},
 			Pagination: RedTeamPagination{Total: 1},
@@ -571,7 +646,7 @@ func TestDualEndpointRouting(t *testing.T) {
 	}
 }
 
-// --- Reports (untested methods) ---
+// --- Reports (additional methods) ---
 
 func TestReports_GetAttackDetail(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
@@ -629,7 +704,10 @@ func TestReports_GetStaticRemediation(t *testing.T) {
 
 func TestReports_GetStaticRuntimePolicy(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(RuntimeSecurityProfileResponse{JobID: "job-1"})
+		if !strings.Contains(r.URL.Path, "/runtime-policy-config") {
+			t.Errorf("path should contain /runtime-policy-config, got %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(RuntimePolicyConfigResponse{JobID: "job-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -663,7 +741,10 @@ func TestReports_GetDynamicRemediation(t *testing.T) {
 
 func TestReports_GetDynamicRuntimePolicy(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(RuntimeSecurityProfileResponse{JobID: "job-1"})
+		if !strings.Contains(r.URL.Path, "/runtime-policy-config") {
+			t.Errorf("path should contain /runtime-policy-config, got %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(RuntimePolicyConfigResponse{JobID: "job-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -715,7 +796,33 @@ func TestReports_GetStreamDetail(t *testing.T) {
 	}
 }
 
-// --- CustomAttackReports (untested methods) ---
+func TestReports_DownloadReport(t *testing.T) {
+	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/v1/report/job-1/download") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("file_format") != "PDF" {
+			t.Errorf("file_format = %s", r.URL.Query().Get("file_format"))
+		}
+		_, _ = w.Write([]byte("fake-pdf-content"))
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
+	data, err := client.Reports.DownloadReport(context.Background(), "job-1", FileFormatPDF)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "fake-pdf-content" {
+		t.Errorf("data = %q", string(data))
+	}
+}
+
+// --- CustomAttackReports (additional methods) ---
 
 func TestCustomAttackReports_GetPromptSets(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
@@ -822,7 +929,7 @@ func TestCustomAttackReports_GetPropertyStats(t *testing.T) {
 	}
 }
 
-// --- Convenience methods (untested) ---
+// --- Convenience methods (additional) ---
 
 func TestGetScoreTrend(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
@@ -905,6 +1012,9 @@ func TestTargets_UpdateProfile(t *testing.T) {
 
 func TestCustomAttacks_GetPromptSet(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "test"})
 	})
 	defer tokenSrv.Close()
@@ -924,6 +1034,9 @@ func TestCustomAttacks_UpdatePromptSet(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {
 			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1") {
+			t.Errorf("path = %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1", Name: "updated"})
 	})
@@ -945,6 +1058,9 @@ func TestCustomAttacks_ArchivePromptSet(t *testing.T) {
 		if r.Method != "PUT" {
 			t.Errorf("method = %s", r.Method)
 		}
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/archive") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetResponse{UUID: "ps-1"})
 	})
 	defer tokenSrv.Close()
@@ -962,6 +1078,9 @@ func TestCustomAttacks_ArchivePromptSet(t *testing.T) {
 
 func TestCustomAttacks_GetPromptSetReference(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/reference") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetReference{UUID: "ps-1"})
 	})
 	defer tokenSrv.Close()
@@ -979,6 +1098,9 @@ func TestCustomAttacks_GetPromptSetReference(t *testing.T) {
 
 func TestCustomAttacks_GetPromptSetVersionInfo(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/version-info") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetVersionInfo{UUID: "ps-1"})
 	})
 	defer tokenSrv.Close()
@@ -996,6 +1118,9 @@ func TestCustomAttacks_GetPromptSetVersionInfo(t *testing.T) {
 
 func TestCustomAttacks_ListActivePromptSets(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/active-custom-prompt-sets") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptSetListActive{
 			Items: []CustomPromptSetResponse{{UUID: "ps-1"}},
 		})
@@ -1018,13 +1143,31 @@ func TestCustomAttacks_CreatePrompt(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("method = %s", r.Method)
 		}
-		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
+		if !strings.HasSuffix(r.URL.Path, "/v1/custom-attack/custom-prompt-set/custom-prompt") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var req CustomPromptCreateRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.PromptSetID != "ps-1" {
+			t.Errorf("PromptSetID = %q", req.PromptSetID)
+		}
+		if req.Prompt != "test prompt" {
+			t.Errorf("Prompt = %q", req.Prompt)
+		}
+		if req.Goal != "test goal" {
+			t.Errorf("Goal = %q", req.Goal)
+		}
+		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1", Prompt: "test prompt", Goal: "test goal"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
-	resp, err := client.CustomAttacks.CreatePrompt(context.Background(), CustomPromptCreateRequest{})
+	resp, err := client.CustomAttacks.CreatePrompt(context.Background(), CustomPromptCreateRequest{
+		PromptSetID: "ps-1",
+		Prompt:      "test prompt",
+		Goal:        "test goal",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1035,6 +1178,9 @@ func TestCustomAttacks_CreatePrompt(t *testing.T) {
 
 func TestCustomAttacks_ListPrompts(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/list-custom-prompts") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptList{
 			Items:      []CustomPromptResponse{{UUID: "p-1"}},
 			Pagination: RedTeamPagination{Total: 1},
@@ -1055,6 +1201,9 @@ func TestCustomAttacks_ListPrompts(t *testing.T) {
 
 func TestCustomAttacks_GetPrompt(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/custom-prompt/p-1") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
 	})
 	defer tokenSrv.Close()
@@ -1075,6 +1224,9 @@ func TestCustomAttacks_UpdatePrompt(t *testing.T) {
 		if r.Method != "PUT" {
 			t.Errorf("method = %s", r.Method)
 		}
+		if !strings.Contains(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/custom-prompt/p-1") {
+			t.Errorf("path = %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomPromptResponse{UUID: "p-1"})
 	})
 	defer tokenSrv.Close()
@@ -1094,6 +1246,9 @@ func TestCustomAttacks_DeletePrompt(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "DELETE" {
 			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/v1/custom-attack/custom-prompt-set/ps-1/custom-prompt/p-1") {
+			t.Errorf("path = %s", r.URL.Path)
 		}
 		_ = json.NewEncoder(w).Encode(BaseResponse{Message: "deleted"})
 	})
@@ -1186,5 +1341,144 @@ func TestCustomAttacks_CreatePropertyValue(t *testing.T) {
 	}
 	if resp.Message != "created" {
 		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+// --- JSON round-trip tests ---
+
+func TestJobCreateRequest_JSON(t *testing.T) {
+	req := JobCreateRequest{
+		Name:    "test-job",
+		Target:  TargetJobRequest{UUID: "t-1", Version: 2},
+		JobType: JobTypeStatic,
+		JobMetadata: map[string]any{
+			"key": "value",
+		},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"target":{`) {
+		t.Errorf("missing target object: %s", s)
+	}
+	if !strings.Contains(s, `"job_metadata":{`) {
+		t.Errorf("missing job_metadata: %s", s)
+	}
+	if strings.Contains(s, `"target_id"`) {
+		t.Errorf("should not contain target_id: %s", s)
+	}
+	if strings.Contains(s, `"metadata"`) {
+		t.Errorf("should not contain metadata: %s", s)
+	}
+}
+
+func TestJobResponse_JSON(t *testing.T) {
+	raw := `{
+		"uuid": "job-1",
+		"name": "test",
+		"tsg_id": "tsg-123",
+		"target": {"uuid": "t-1", "name": "tgt", "version": 3},
+		"job_type": "STATIC",
+		"status": "COMPLETED",
+		"job_metadata": {"key": "val"},
+		"version": 1,
+		"target_type": "APPLICATION",
+		"total": 100,
+		"completed": 95,
+		"score": 0.85,
+		"asr": 0.15
+	}`
+	var resp JobResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "job-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+	if resp.TsgID != "tsg-123" {
+		t.Errorf("TsgID = %q", resp.TsgID)
+	}
+	if resp.Target.UUID != "t-1" {
+		t.Errorf("Target.UUID = %q", resp.Target.UUID)
+	}
+	if resp.Total != 100 {
+		t.Errorf("Total = %d", resp.Total)
+	}
+	if resp.Completed != 95 {
+		t.Errorf("Completed = %d", resp.Completed)
+	}
+	if resp.Score != 0.85 {
+		t.Errorf("Score = %f", resp.Score)
+	}
+	if resp.ASR != 0.15 {
+		t.Errorf("ASR = %f", resp.ASR)
+	}
+}
+
+func TestCustomPromptCreateRequest_JSON(t *testing.T) {
+	req := CustomPromptCreateRequest{
+		PromptSetID: "ps-1",
+		Prompt:      "test prompt",
+		Goal:        "test goal",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"prompt_set_id":"ps-1"`) {
+		t.Errorf("missing prompt_set_id: %s", s)
+	}
+	if !strings.Contains(s, `"prompt":"test prompt"`) {
+		t.Errorf("missing prompt: %s", s)
+	}
+	if !strings.Contains(s, `"goal":"test goal"`) {
+		t.Errorf("missing goal: %s", s)
+	}
+	if strings.Contains(s, `"content"`) {
+		t.Errorf("should not contain content: %s", s)
+	}
+	if strings.Contains(s, `"prompt_set_uuid"`) {
+		t.Errorf("should not contain prompt_set_uuid: %s", s)
+	}
+}
+
+func TestCustomPromptResponse_JSON(t *testing.T) {
+	raw := `{
+		"uuid": "p-1",
+		"prompt_set_id": "ps-1",
+		"prompt": "test",
+		"goal": "a goal",
+		"user_defined_goal": "user goal",
+		"detector_category": "security",
+		"severity": "HIGH",
+		"active": true
+	}`
+	var resp CustomPromptResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.UUID != "p-1" {
+		t.Errorf("UUID = %q", resp.UUID)
+	}
+	if resp.PromptSetID != "ps-1" {
+		t.Errorf("PromptSetID = %q", resp.PromptSetID)
+	}
+	if resp.Prompt != "test" {
+		t.Errorf("Prompt = %q", resp.Prompt)
+	}
+	if resp.Goal != "a goal" {
+		t.Errorf("Goal = %q", resp.Goal)
+	}
+	if resp.UserDefinedGoal != "user goal" {
+		t.Errorf("UserDefinedGoal = %q", resp.UserDefinedGoal)
+	}
+	if resp.DetectorCategory != "security" {
+		t.Errorf("DetectorCategory = %q", resp.DetectorCategory)
+	}
+	if resp.Severity != "HIGH" {
+		t.Errorf("Severity = %q", resp.Severity)
 	}
 }

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -59,6 +59,15 @@ const (
 	TargetConnectionTypeStreaming   TargetConnectionType = "STREAMING"
 )
 
+// APIEndpointType represents the API endpoint type for a target.
+type APIEndpointType string
+
+const (
+	APIEndpointTypeChatCompletion APIEndpointType = "CHAT_COMPLETION"
+	APIEndpointTypeCompletion     APIEndpointType = "COMPLETION"
+	APIEndpointTypeCustom         APIEndpointType = "CUSTOM"
+)
+
 // RedTeamCategory represents a red team attack category.
 type RedTeamCategory string
 
@@ -96,6 +105,15 @@ const (
 	GoalTypeGoalManipulation GoalType = "GOAL_MANIPULATION"
 )
 
+// FileFormat represents a report download format.
+type FileFormat string
+
+const (
+	FileFormatPDF  FileFormat = "PDF"
+	FileFormatCSV  FileFormat = "CSV"
+	FileFormatJSON FileFormat = "JSON"
+)
+
 // --- Pagination ---
 
 // RedTeamPagination holds pagination metadata.
@@ -107,26 +125,45 @@ type RedTeamPagination struct {
 
 // --- Job / Scan types ---
 
+// TargetJobRequest is the nested target reference in a job create request.
+type TargetJobRequest struct {
+	UUID    string `json:"uuid"`
+	Version int    `json:"version,omitempty"`
+}
+
 // JobCreateRequest is the request to create a red team scan job.
 type JobCreateRequest struct {
-	TargetID string         `json:"target_id"`
-	JobType  JobType        `json:"job_type"`
-	Name     string         `json:"name,omitempty"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	Name        string           `json:"name"`
+	Target      TargetJobRequest `json:"target"`
+	JobType     JobType          `json:"job_type"`
+	JobMetadata map[string]any   `json:"job_metadata,omitempty"`
+}
+
+// JobTargetResponse is the nested target info in a job response.
+type JobTargetResponse struct {
+	UUID    string `json:"uuid,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version int    `json:"version,omitempty"`
 }
 
 // JobResponse represents a red team scan job.
 type JobResponse struct {
-	ID         string         `json:"id"`
-	Name       string         `json:"name,omitempty"`
-	TargetID   string         `json:"target_id,omitempty"`
-	JobType    JobType        `json:"job_type,omitempty"`
-	Status     JobStatus      `json:"status,omitempty"`
-	Metadata   map[string]any `json:"metadata,omitempty"`
-	Stats      map[string]any `json:"stats,omitempty"`
-	CreatedAt  string         `json:"created_at,omitempty"`
-	UpdatedAt  string         `json:"updated_at,omitempty"`
-	FinishedAt string         `json:"finished_at,omitempty"`
+	UUID        string            `json:"uuid"`
+	Name        string            `json:"name,omitempty"`
+	TsgID       string            `json:"tsg_id,omitempty"`
+	Target      JobTargetResponse `json:"target,omitempty"`
+	JobType     JobType           `json:"job_type,omitempty"`
+	Status      JobStatus         `json:"status,omitempty"`
+	JobMetadata map[string]any    `json:"job_metadata,omitempty"`
+	Version     int               `json:"version,omitempty"`
+	TargetType  TargetType        `json:"target_type,omitempty"`
+	Total       int               `json:"total,omitempty"`
+	Completed   int               `json:"completed,omitempty"`
+	Score       float64           `json:"score,omitempty"`
+	ASR         float64           `json:"asr,omitempty"`
+	CreatedAt   string            `json:"created_at,omitempty"`
+	UpdatedAt   string            `json:"updated_at,omitempty"`
+	FinishedAt  string            `json:"finished_at,omitempty"`
 }
 
 // JobListResponse is the paginated list of jobs.
@@ -171,6 +208,11 @@ type DynamicJobReport struct {
 	Details map[string]any `json:"details,omitempty"`
 }
 
+// ReportDownloadResponse wraps raw bytes from a report download.
+type ReportDownloadResponse struct {
+	Data []byte `json:"data,omitempty"`
+}
+
 // AttackListItem represents an attack in a list.
 type AttackListItem struct {
 	ID       string         `json:"id,omitempty"`
@@ -207,8 +249,8 @@ type RemediationResponse struct {
 	Details map[string]any `json:"details,omitempty"`
 }
 
-// RuntimeSecurityProfileResponse is the runtime security profile.
-type RuntimeSecurityProfileResponse struct {
+// RuntimePolicyConfigResponse is the runtime policy configuration.
+type RuntimePolicyConfigResponse struct {
 	JobID    string         `json:"job_id,omitempty"`
 	Policies map[string]any `json:"policies,omitempty"`
 }
@@ -331,7 +373,21 @@ type TargetList struct {
 
 // TargetProbeRequest is the request to probe a target.
 type TargetProbeRequest struct {
-	UUID string `json:"uuid"`
+	Name                     string               `json:"name"`
+	Description              string               `json:"description,omitempty"`
+	TargetType               TargetType           `json:"target_type,omitempty"`
+	ConnectionType           TargetConnectionType `json:"connection_type,omitempty"`
+	APIEndpointType          APIEndpointType      `json:"api_endpoint_type,omitempty"`
+	ResponseMode             ResponseMode         `json:"response_mode,omitempty"`
+	SessionSupported         *bool                `json:"session_supported,omitempty"`
+	ConnectionParams         map[string]any       `json:"connection_params,omitempty"`
+	NetworkBrokerChannelUUID string               `json:"network_broker_channel_uuid,omitempty"`
+	ExtraInfo                map[string]any       `json:"extra_info,omitempty"`
+	TargetMetadata           map[string]any       `json:"target_metadata,omitempty"`
+	TargetBackground         map[string]any       `json:"target_background,omitempty"`
+	AdditionalContext        map[string]any       `json:"additional_context,omitempty"`
+	UUID                     string               `json:"uuid,omitempty"`
+	ProbeFields              []string             `json:"probe_fields,omitempty"`
 }
 
 // TargetProfileResponse is the target profile.
@@ -404,25 +460,31 @@ type CustomPromptSetVersionInfo struct {
 
 // CustomPromptCreateRequest is the request to create a prompt.
 type CustomPromptCreateRequest struct {
-	PromptSetUUID string         `json:"prompt_set_uuid"`
-	Content       string         `json:"content"`
-	Properties    map[string]any `json:"properties,omitempty"`
+	PromptSetID string         `json:"prompt_set_id"`
+	Prompt      string         `json:"prompt"`
+	Goal        string         `json:"goal,omitempty"`
+	Properties  map[string]any `json:"properties,omitempty"`
 }
 
 // CustomPromptUpdateRequest is the request to update a prompt.
 type CustomPromptUpdateRequest struct {
-	Content    string         `json:"content,omitempty"`
+	Prompt     string         `json:"prompt,omitempty"`
+	Goal       string         `json:"goal,omitempty"`
 	Properties map[string]any `json:"properties,omitempty"`
 }
 
 // CustomPromptResponse represents a custom prompt.
 type CustomPromptResponse struct {
-	UUID          string         `json:"uuid"`
-	PromptSetUUID string         `json:"prompt_set_uuid,omitempty"`
-	Content       string         `json:"content,omitempty"`
-	Properties    map[string]any `json:"properties,omitempty"`
-	Active        bool           `json:"active,omitempty"`
-	CreatedAt     string         `json:"created_at,omitempty"`
+	UUID             string         `json:"uuid"`
+	PromptSetID      string         `json:"prompt_set_id,omitempty"`
+	Prompt           string         `json:"prompt,omitempty"`
+	Goal             string         `json:"goal,omitempty"`
+	UserDefinedGoal  string         `json:"user_defined_goal,omitempty"`
+	DetectorCategory string         `json:"detector_category,omitempty"`
+	Severity         string         `json:"severity,omitempty"`
+	Properties       map[string]any `json:"properties,omitempty"`
+	Active           bool           `json:"active,omitempty"`
+	CreatedAt        string         `json:"created_at,omitempty"`
 }
 
 // CustomPromptList is the paginated list of prompts.


### PR DESCRIPTION
## Summary
- Fixes all custom-attack endpoint paths to match management spec
- Fixes runtime policy config paths on data plane
- Restructures job request/response models per data plane spec
- Expands TargetProbeRequest to all 15 spec fields

## Changes
- All custom-attack paths corrected (prompt-set→custom-prompt-set, etc.)
- Runtime policy: /runtime-security-profile→/runtime-policy-config
- JobCreateRequest: nested `target: {uuid, version}`, `job_metadata` field name
- JobResponse: `uuid` primary ID, added tsg_id/total/completed/score/asr
- TargetProbeRequest: 1→15 fields
- CustomPrompt models: Content→Prompt, add Goal/Severity/DetectorCategory
- New DownloadReport method

## Testing
- 55+ unit tests (6 new JSON round-trip + path verification tests)
- All existing tests updated and passing

Closes #29