### PR TITLE
fix: align all 4 packages with OpenAPI specs

### DIFF
--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -184,7 +184,7 @@ func TestApiKeys_Create(t *testing.T) {
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
-	key, err := client.ApiKeys.Create(context.Background(), CreateApiKeyRequest{ApiKeyName: "test-key"})
+	key, err := client.ApiKeys.Create(context.Background(), CreateApiKeyRequest{ApiKeyName: "test-key", AuthCode: "ac-1", Revoked: false, CustApp: "app1", CreatedBy: "user@example.com", RotationTimeInterval: 90, RotationTimeUnit: "days"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,27 +195,27 @@ func TestApiKeys_Create(t *testing.T) {
 
 func TestCustomerApps_CRUD(t *testing.T) {
 	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(CustomerApp{AppID: "a-1", AppName: "test-app"})
+		_ = json.NewEncoder(w).Encode(CustomerApp{CustomerAppID: "a-1", AppName: "test-app"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
 
-	app, err := client.CustomerApps.Create(context.Background(), CreateAppRequest{AppName: "test-app"})
+	app, err := client.CustomerApps.Create(context.Background(), CreateAppRequest{AppName: "test-app", TsgID: "123", CloudProvider: "aws", Environment: "prod"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if app.AppID != "a-1" {
-		t.Errorf("AppID = %q", app.AppID)
+	if app.CustomerAppID != "a-1" {
+		t.Errorf("CustomerAppID = %q", app.CustomerAppID)
 	}
 
 	got, err := client.CustomerApps.Get(context.Background(), "test-app")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.AppID != "a-1" {
-		t.Errorf("AppID = %q", got.AppID)
+	if got.CustomerAppID != "a-1" {
+		t.Errorf("CustomerAppID = %q", got.CustomerAppID)
 	}
 }
 
@@ -231,7 +231,7 @@ func TestCustomerApps_Get_QueryParam(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/customerapp/") {
 			t.Errorf("path = %q, should not have path param", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(CustomerApp{AppID: "a-1", AppName: "my-app"})
+		_ = json.NewEncoder(w).Encode(CustomerApp{CustomerAppID: "a-1", AppName: "my-app"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -254,7 +254,7 @@ func TestCustomerApps_Update_QueryParam(t *testing.T) {
 		if r.URL.Query().Get("customer_app_id") != "app-123" {
 			t.Errorf("customer_app_id = %q, want app-123", r.URL.Query().Get("customer_app_id"))
 		}
-		_ = json.NewEncoder(w).Encode(CustomerApp{AppID: "app-123", AppName: "updated"})
+		_ = json.NewEncoder(w).Encode(CustomerApp{CustomerAppID: "app-123", AppName: "updated"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -668,7 +668,7 @@ func TestCustomerApps_List(t *testing.T) {
 			t.Errorf("method = %s", r.Method)
 		}
 		_ = json.NewEncoder(w).Encode(CustomerAppListResponse{
-			Items: []CustomerApp{{AppID: "a-1"}},
+			Items: []CustomerApp{{CustomerAppID: "a-1"}},
 		})
 	})
 	defer tokenSrv.Close()
@@ -741,6 +741,158 @@ func TestOAuth_InvalidateToken(t *testing.T) {
 	}
 	if resp.Message != "invalidated" {
 		t.Errorf("Message = %q", resp.Message)
+	}
+}
+
+func TestSecurityProfile_JSONRoundTrip(t *testing.T) {
+	p := SecurityProfile{
+		ProfileID:      "p-1",
+		ProfileName:    "test-profile",
+		Revision:       3,
+		Active:         true,
+		Policy:         map[string]any{"key": "val"},
+		CreatedBy:      "user@example.com",
+		UpdatedBy:      "admin@example.com",
+		LastModifiedTs: "2025-06-01T00:00:00Z",
+	}
+
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded SecurityProfile
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.ProfileID != p.ProfileID {
+		t.Errorf("ProfileID = %q", decoded.ProfileID)
+	}
+	if decoded.Revision != p.Revision {
+		t.Errorf("Revision = %d", decoded.Revision)
+	}
+	if decoded.CreatedBy != p.CreatedBy {
+		t.Errorf("CreatedBy = %q", decoded.CreatedBy)
+	}
+	if decoded.UpdatedBy != p.UpdatedBy {
+		t.Errorf("UpdatedBy = %q", decoded.UpdatedBy)
+	}
+	if decoded.LastModifiedTs != p.LastModifiedTs {
+		t.Errorf("LastModifiedTs = %q", decoded.LastModifiedTs)
+	}
+
+	// Verify JSON key names
+	var raw map[string]any
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["created_by"]; !ok {
+		t.Error("missing created_by in JSON")
+	}
+	if _, ok := raw["updated_by"]; !ok {
+		t.Error("missing updated_by in JSON")
+	}
+	if _, ok := raw["revision"]; !ok {
+		t.Error("missing revision in JSON")
+	}
+}
+
+func TestCustomTopic_JSONRoundTrip(t *testing.T) {
+	topic := CustomTopic{
+		TopicID:        "t-1",
+		TopicName:      "test-topic",
+		Revision:       5,
+		Active:         true,
+		Description:    "a test topic",
+		Examples:       []string{"ex1", "ex2"},
+		CreatedBy:      "user@example.com",
+		UpdatedBy:      "admin@example.com",
+		LastModifiedTs: "2025-06-01T00:00:00Z",
+		CreatedTs:      "2025-01-01T00:00:00Z",
+	}
+
+	data, err := json.Marshal(topic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded CustomTopic
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.TopicID != topic.TopicID {
+		t.Errorf("TopicID = %q", decoded.TopicID)
+	}
+	if decoded.Revision != topic.Revision {
+		t.Errorf("Revision = %d", decoded.Revision)
+	}
+	if decoded.Active != topic.Active {
+		t.Errorf("Active = %v", decoded.Active)
+	}
+	if decoded.CreatedBy != topic.CreatedBy {
+		t.Errorf("CreatedBy = %q", decoded.CreatedBy)
+	}
+	if decoded.CreatedTs != topic.CreatedTs {
+		t.Errorf("CreatedTs = %q", decoded.CreatedTs)
+	}
+	if decoded.LastModifiedTs != topic.LastModifiedTs {
+		t.Errorf("LastModifiedTs = %q", decoded.LastModifiedTs)
+	}
+
+	var raw map[string]any
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["revision"]; !ok {
+		t.Error("missing revision in JSON")
+	}
+	if _, ok := raw["created_ts"]; !ok {
+		t.Error("missing created_ts in JSON")
+	}
+}
+
+func TestCustomerApp_JSONRoundTrip(t *testing.T) {
+	app := CustomerApp{
+		CustomerAppID:    "app-1",
+		AppName:          "test-app",
+		TsgID:            "tsg-1",
+		ModelName:        "gpt-4",
+		CloudProvider:    "aws",
+		Environment:      "production",
+		Status:           "active",
+		CreatedBy:        "user@example.com",
+		UpdatedBy:        "admin@example.com",
+		AiAgentFramework: "langchain",
+	}
+
+	data, err := json.Marshal(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded CustomerApp
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.CustomerAppID != app.CustomerAppID {
+		t.Errorf("CustomerAppID = %q", decoded.CustomerAppID)
+	}
+	if decoded.TsgID != app.TsgID {
+		t.Errorf("TsgID = %q", decoded.TsgID)
+	}
+	if decoded.CloudProvider != app.CloudProvider {
+		t.Errorf("CloudProvider = %q", decoded.CloudProvider)
+	}
+	if decoded.AiAgentFramework != app.AiAgentFramework {
+		t.Errorf("AiAgentFramework = %q", decoded.AiAgentFramework)
+	}
+
+	var raw map[string]any
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["customer_appId"]; !ok {
+		t.Error("missing customer_appId in JSON")
+	}
+	if _, ok := raw["ai_agent_framework"]; !ok {
+		t.Error("missing ai_agent_framework in JSON")
 	}
 }
 

--- a/aisec/management/models.go
+++ b/aisec/management/models.go
@@ -8,12 +8,14 @@ type ListOpts struct {
 
 // SecurityProfile represents an AI security profile.
 type SecurityProfile struct {
-	ProfileID   string         `json:"profile_id,omitempty"`
-	ProfileName string         `json:"profile_name,omitempty"`
-	Active      bool           `json:"active,omitempty"`
-	Policy      map[string]any `json:"policy,omitempty"`
-	CreatedAt   string         `json:"created_at,omitempty"`
-	UpdatedAt   string         `json:"updated_at,omitempty"`
+	ProfileID      string         `json:"profile_id,omitempty"`
+	ProfileName    string         `json:"profile_name,omitempty"`
+	Revision       int32          `json:"revision,omitempty"`
+	Active         bool           `json:"active,omitempty"`
+	Policy         map[string]any `json:"policy,omitempty"`
+	CreatedBy      string         `json:"created_by,omitempty"`
+	UpdatedBy      string         `json:"updated_by,omitempty"`
+	LastModifiedTs string         `json:"last_modified_ts,omitempty"`
 }
 
 // SecurityProfileListResponse is the list response for profiles.
@@ -41,12 +43,16 @@ type DeleteProfileResponse struct {
 
 // CustomTopic represents a custom detection topic.
 type CustomTopic struct {
-	TopicID     string   `json:"topic_id,omitempty"`
-	TopicName   string   `json:"topic_name,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Examples    []string `json:"examples,omitempty"`
-	CreatedAt   string   `json:"created_at,omitempty"`
-	UpdatedAt   string   `json:"updated_at,omitempty"`
+	TopicID        string   `json:"topic_id,omitempty"`
+	TopicName      string   `json:"topic_name,omitempty"`
+	Revision       int64    `json:"revision,omitempty"`
+	Active         bool     `json:"active,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Examples       []string `json:"examples,omitempty"`
+	CreatedBy      string   `json:"created_by,omitempty"`
+	UpdatedBy      string   `json:"updated_by,omitempty"`
+	LastModifiedTs string   `json:"last_modified_ts,omitempty"`
+	CreatedTs      string   `json:"created_ts,omitempty"`
 }
 
 // CustomTopicListResponse is the list response for topics.
@@ -111,8 +117,17 @@ type ApiKeyListResponse struct {
 
 // CreateApiKeyRequest is the request to create an API key.
 type CreateApiKeyRequest struct {
-	ApiKeyName string `json:"api_key_name"`
-	UpdatedBy  string `json:"updated_by,omitempty"`
+	ApiKeyName           string `json:"api_key_name"`
+	AuthCode             string `json:"auth_code"`
+	Revoked              bool   `json:"revoked"`
+	CustApp              string `json:"cust_app"`
+	CreatedBy            string `json:"created_by"`
+	RotationTimeInterval int    `json:"rotation_time_interval"`
+	RotationTimeUnit     string `json:"rotation_time_unit"`
+	DpName               string `json:"dp_name,omitempty"`
+	CustEnv              string `json:"cust_env,omitempty"`
+	CustCloudProvider    string `json:"cust_cloud_provider,omitempty"`
+	CustAIAgentFramework string `json:"cust_ai_agent_framework,omitempty"`
 }
 
 // RegenerateKeyRequest is the request to regenerate an API key.
@@ -127,11 +142,16 @@ type ApiKeyDeleteResponse struct {
 
 // CustomerApp represents a customer application.
 type CustomerApp struct {
-	AppID       string `json:"app_id,omitempty"`
-	AppName     string `json:"app_name,omitempty"`
-	Description string `json:"description,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
+	CustomerAppID    string `json:"customer_appId,omitempty"`
+	AppName          string `json:"app_name,omitempty"`
+	TsgID            string `json:"tsg_id,omitempty"`
+	ModelName        string `json:"model_name,omitempty"`
+	CloudProvider    string `json:"cloud_provider,omitempty"`
+	Environment      string `json:"environment,omitempty"`
+	Status           string `json:"status,omitempty"`
+	CreatedBy        string `json:"created_by,omitempty"`
+	UpdatedBy        string `json:"updated_by,omitempty"`
+	AiAgentFramework string `json:"ai_agent_framework,omitempty"`
 }
 
 // CustomerAppListResponse is the list response for customer apps.
@@ -142,14 +162,18 @@ type CustomerAppListResponse struct {
 
 // CreateAppRequest is the request to create a customer app.
 type CreateAppRequest struct {
-	AppName     string `json:"app_name"`
-	Description string `json:"description,omitempty"`
+	AppName       string `json:"app_name"`
+	TsgID         string `json:"tsg_id"`
+	CloudProvider string `json:"cloud_provider"`
+	Environment   string `json:"environment"`
 }
 
 // UpdateAppRequest is the request to update a customer app.
 type UpdateAppRequest struct {
-	AppName     string `json:"app_name,omitempty"`
-	Description string `json:"description,omitempty"`
+	AppName       string `json:"app_name,omitempty"`
+	ModelName     string `json:"model_name,omitempty"`
+	CloudProvider string `json:"cloud_provider,omitempty"`
+	Environment   string `json:"environment,omitempty"`
 }
 
 // DeleteAppResponse is the response from deleting a customer app.
@@ -178,12 +202,12 @@ type DlpProfileListResponse struct {
 
 // DeploymentProfile represents a deployment profile.
 type DeploymentProfile struct {
-	AuthCode             string `json:"auth_code,omitempty"`
-	DpName               string `json:"dp_name,omitempty"`
-	ExpirationDate       string `json:"expiration_date,omitempty"`
-	MonthlyBillionTokens int    `json:"monthly_billion_tokens,omitempty"`
-	Status               string `json:"status,omitempty"`
-	TsgID                string `json:"tsg_id,omitempty"`
+	AuthCode       string `json:"auth_code,omitempty"`
+	DpName         string `json:"dp_name,omitempty"`
+	TsgID          string `json:"tsg_id,omitempty"`
+	Status         string `json:"status,omitempty"`
+	ExpirationDate string `json:"expiration_date,omitempty"`
+	AveTextRecords int32  `json:"ave_text_records,omitempty"`
 }
 
 // DeploymentProfileListResponse is the list response for deployment profiles.

--- a/aisec/modelsecurity/client.go
+++ b/aisec/modelsecurity/client.go
@@ -402,9 +402,6 @@ func buildScanListParams(opts ScanListOpts) map[string]string {
 	if opts.Limit > 0 {
 		params["limit"] = fmt.Sprintf("%d", opts.Limit)
 	}
-	if opts.SortBy != "" {
-		params["sort_by"] = opts.SortBy
-	}
 	if opts.SortOrder != "" {
 		params["sort_order"] = opts.SortOrder
 	}

--- a/aisec/modelsecurity/client_test.go
+++ b/aisec/modelsecurity/client_test.go
@@ -678,6 +678,89 @@ func TestListResponses_JSONTags(t *testing.T) {
 	}
 }
 
+func TestErrorCode_Constants(t *testing.T) {
+	codes := []ErrorCode{
+		ErrorCodeUnknownError, ErrorCodeScanError, ErrorCodeInvalidResponse,
+		ErrorCodeAccessDenied, ErrorCodeMissingCredentials, ErrorCodeNoSuchKey,
+		ErrorCodeNoSuchBucket, ErrorCodeInvalidBucketName, ErrorCodeInternalError,
+		ErrorCodeServiceUnavailable, ErrorCodeInvalidObjectState,
+		ErrorCodeUnknownRemoteServiceError, ErrorCodeUnsupportedRemoteStorage,
+		ErrorCodeMissingArtifacts, ErrorCodeWorkerError, ErrorCodePolicyEvalError,
+	}
+	if len(codes) != 16 {
+		t.Errorf("expected 16 error codes, got %d", len(codes))
+	}
+	if string(ErrorCodeScanError) != "SCAN_ERROR" {
+		t.Errorf("ErrorCodeScanError = %q", ErrorCodeScanError)
+	}
+}
+
+func TestThreatCategory_Constants(t *testing.T) {
+	cats := []ThreatCategory{
+		ThreatCategoryPAITARV100, ThreatCategoryPAITGGUF100, ThreatCategoryPAITGGUF101,
+		ThreatCategoryPAITKERAS100, ThreatCategoryPAITKERAS101, ThreatCategoryPAITKERAS102,
+		ThreatCategoryPAITJOBLIB100, ThreatCategoryPAITJOBLIB101,
+		ThreatCategoryPAITPKL100, ThreatCategoryPAITPKL101,
+		ThreatCategoryPAITPYTCH100, ThreatCategoryPAITPYTCH101,
+		ThreatCategoryPAITEXDIR100, ThreatCategoryPAITEXDIR101,
+		ThreatCategoryPAITONNX200, ThreatCategoryPAITTF200,
+		ThreatCategoryPAITLMAFL300, ThreatCategoryPAITLITERT300,
+		ThreatCategoryPAITLITERT301, ThreatCategoryPAITLITERT302,
+		ThreatCategoryPAITKERAS300, ThreatCategoryPAITKERAS301,
+		ThreatCategoryPAITTCHST300, ThreatCategoryPAITTCHST301,
+		ThreatCategoryPAITTF300, ThreatCategoryPAITTF301, ThreatCategoryPAITTF302,
+		ThreatCategoryPAITTMT300, ThreatCategoryPAITTMT301,
+		ThreatCategoryUnapprovedFormats,
+	}
+	if len(cats) != 30 {
+		t.Errorf("expected 30 threat categories, got %d", len(cats))
+	}
+	if string(ThreatCategoryPAITARV100) != "PAIT-ARV-100" {
+		t.Errorf("ThreatCategoryPAITARV100 = %q", ThreatCategoryPAITARV100)
+	}
+}
+
+func TestLabelsResponse_EmptyJSON(t *testing.T) {
+	raw := `{}`
+	var resp LabelsResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Labels != nil {
+		t.Errorf("expected nil labels, got %v", resp.Labels)
+	}
+
+	// Round-trip with labels
+	raw2 := `{"labels":[{"key":"env","value":"prod"}]}`
+	var resp2 LabelsResponse
+	if err := json.Unmarshal([]byte(raw2), &resp2); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp2.Labels) != 1 || resp2.Labels[0].Key != "env" {
+		t.Errorf("labels = %v", resp2.Labels)
+	}
+
+	// Marshal empty omits labels
+	data, err := json.Marshal(LabelsResponse{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "{}" {
+		t.Errorf("empty marshal = %s", string(data))
+	}
+}
+
+func TestScanListOpts_NoSortBy(t *testing.T) {
+	opts := ScanListOpts{Limit: 10, SortOrder: "desc"}
+	params := buildScanListParams(opts)
+	if _, ok := params["sort_by"]; ok {
+		t.Error("sort_by should not be in params")
+	}
+	if params["sort_order"] != "desc" {
+		t.Errorf("sort_order = %q", params["sort_order"])
+	}
+}
+
 func TestBuildGroupListParams_SourceTypesAndEnabledRules(t *testing.T) {
 	params := buildGroupListParams(GroupListOpts{
 		SourceTypes:  []string{"LOCAL", "S3"},

--- a/aisec/modelsecurity/models.go
+++ b/aisec/modelsecurity/models.go
@@ -114,8 +114,60 @@ const (
 // ThreatCategory represents threat categories for model scan issues.
 type ThreatCategory string
 
+const (
+	ThreatCategoryPAITARV100        ThreatCategory = "PAIT-ARV-100"
+	ThreatCategoryPAITGGUF100       ThreatCategory = "PAIT-GGUF-100"
+	ThreatCategoryPAITGGUF101       ThreatCategory = "PAIT-GGUF-101"
+	ThreatCategoryPAITKERAS100      ThreatCategory = "PAIT-KERAS-100"
+	ThreatCategoryPAITKERAS101      ThreatCategory = "PAIT-KERAS-101"
+	ThreatCategoryPAITKERAS102      ThreatCategory = "PAIT-KERAS-102"
+	ThreatCategoryPAITJOBLIB100     ThreatCategory = "PAIT-JOBLIB-100"
+	ThreatCategoryPAITJOBLIB101     ThreatCategory = "PAIT-JOBLIB-101"
+	ThreatCategoryPAITPKL100        ThreatCategory = "PAIT-PKL-100"
+	ThreatCategoryPAITPKL101        ThreatCategory = "PAIT-PKL-101"
+	ThreatCategoryPAITPYTCH100      ThreatCategory = "PAIT-PYTCH-100"
+	ThreatCategoryPAITPYTCH101      ThreatCategory = "PAIT-PYTCH-101"
+	ThreatCategoryPAITEXDIR100      ThreatCategory = "PAIT-EXDIR-100"
+	ThreatCategoryPAITEXDIR101      ThreatCategory = "PAIT-EXDIR-101"
+	ThreatCategoryPAITONNX200       ThreatCategory = "PAIT-ONNX-200"
+	ThreatCategoryPAITTF200         ThreatCategory = "PAIT-TF-200"
+	ThreatCategoryPAITLMAFL300      ThreatCategory = "PAIT-LMAFL-300"
+	ThreatCategoryPAITLITERT300     ThreatCategory = "PAIT-LITERT-300"
+	ThreatCategoryPAITLITERT301     ThreatCategory = "PAIT-LITERT-301"
+	ThreatCategoryPAITLITERT302     ThreatCategory = "PAIT-LITERT-302"
+	ThreatCategoryPAITKERAS300      ThreatCategory = "PAIT-KERAS-300"
+	ThreatCategoryPAITKERAS301      ThreatCategory = "PAIT-KERAS-301"
+	ThreatCategoryPAITTCHST300      ThreatCategory = "PAIT-TCHST-300"
+	ThreatCategoryPAITTCHST301      ThreatCategory = "PAIT-TCHST-301"
+	ThreatCategoryPAITTF300         ThreatCategory = "PAIT-TF-300"
+	ThreatCategoryPAITTF301         ThreatCategory = "PAIT-TF-301"
+	ThreatCategoryPAITTF302         ThreatCategory = "PAIT-TF-302"
+	ThreatCategoryPAITTMT300        ThreatCategory = "PAIT-TMT-300"
+	ThreatCategoryPAITTMT301        ThreatCategory = "PAIT-TMT-301"
+	ThreatCategoryUnapprovedFormats ThreatCategory = "UNAPPROVED_FORMATS"
+)
+
 // ErrorCode represents error codes for scans.
 type ErrorCode string
+
+const (
+	ErrorCodeUnknownError              ErrorCode = "UNKNOWN_ERROR"
+	ErrorCodeScanError                 ErrorCode = "SCAN_ERROR"
+	ErrorCodeInvalidResponse           ErrorCode = "INVALID_RESPONSE"
+	ErrorCodeAccessDenied              ErrorCode = "ACCESS_DENIED"
+	ErrorCodeMissingCredentials        ErrorCode = "MISSING_CREDENTIALS"
+	ErrorCodeNoSuchKey                 ErrorCode = "NO_SUCH_KEY"
+	ErrorCodeNoSuchBucket              ErrorCode = "NO_SUCH_BUCKET"
+	ErrorCodeInvalidBucketName         ErrorCode = "INVALID_BUCKET_NAME"
+	ErrorCodeInternalError             ErrorCode = "INTERNAL_ERROR"
+	ErrorCodeServiceUnavailable        ErrorCode = "SERVICE_UNAVAILABLE"
+	ErrorCodeInvalidObjectState        ErrorCode = "INVALID_OBJECT_STATE"
+	ErrorCodeUnknownRemoteServiceError ErrorCode = "UNKNOWN_REMOTE_SERVICE_ERROR"
+	ErrorCodeUnsupportedRemoteStorage  ErrorCode = "UNSUPPORTED_REMOTE_STORAGE"
+	ErrorCodeMissingArtifacts          ErrorCode = "MISSING_ARTIFACTS"
+	ErrorCodeWorkerError               ErrorCode = "WORKER_ERROR"
+	ErrorCodePolicyEvalError           ErrorCode = "POLICY_EVAL_ERROR"
+)
 
 // RuleFieldValueKey is a valid key for rule field values.
 type RuleFieldValueKey string
@@ -345,7 +397,7 @@ type LabelsCreateRequest struct {
 
 // LabelsResponse is the response from label operations.
 type LabelsResponse struct {
-	Labels []Label `json:"labels"`
+	Labels []Label `json:"labels,omitempty"`
 }
 
 // LabelKeyList is the paginated list of label keys.
@@ -459,7 +511,6 @@ type PyPIAuthResponse struct {
 type ScanListOpts struct {
 	Skip              int
 	Limit             int
-	SortBy            string
 	SortOrder         string
 	SearchQuery       string
 	EvalOutcomes      []string

--- a/aisec/redteam/client_test.go
+++ b/aisec/redteam/client_test.go
@@ -384,7 +384,7 @@ func TestTargets_Probe_AllFields(t *testing.T) {
 		if req.ConnectionType != TargetConnectionTypeRest {
 			t.Errorf("ConnectionType = %q", req.ConnectionType)
 		}
-		if req.APIEndpointType != APIEndpointTypeChatCompletion {
+		if req.APIEndpointType != APIEndpointTypePublic {
 			t.Errorf("APIEndpointType = %q", req.APIEndpointType)
 		}
 		if req.ResponseMode != ResponseModeRest {
@@ -411,7 +411,7 @@ func TestTargets_Probe_AllFields(t *testing.T) {
 		Description:      "A full probe",
 		TargetType:       TargetTypeApplication,
 		ConnectionType:   TargetConnectionTypeRest,
-		APIEndpointType:  APIEndpointTypeChatCompletion,
+		APIEndpointType:  APIEndpointTypePublic,
 		ResponseMode:     ResponseModeRest,
 		SessionSupported: &sessionSupported,
 		ConnectionParams: map[string]any{"url": "https://example.com"},
@@ -804,20 +804,20 @@ func TestReports_DownloadReport(t *testing.T) {
 		if !strings.Contains(r.URL.Path, "/v1/report/job-1/download") {
 			t.Errorf("path = %s", r.URL.Path)
 		}
-		if r.URL.Query().Get("file_format") != "PDF" {
+		if r.URL.Query().Get("file_format") != "JSON" {
 			t.Errorf("file_format = %s", r.URL.Query().Get("file_format"))
 		}
-		_, _ = w.Write([]byte("fake-pdf-content"))
+		_, _ = w.Write([]byte("fake-json-content"))
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL, apiSrv.URL)
-	data, err := client.Reports.DownloadReport(context.Background(), "job-1", FileFormatPDF)
+	data, err := client.Reports.DownloadReport(context.Background(), "job-1", FileFormatJSON)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != "fake-pdf-content" {
+	if string(data) != "fake-json-content" {
 		t.Errorf("data = %q", string(data))
 	}
 }
@@ -1480,5 +1480,170 @@ func TestCustomPromptResponse_JSON(t *testing.T) {
 	}
 	if resp.Severity != "HIGH" {
 		t.Errorf("Severity = %q", resp.Severity)
+	}
+}
+
+func TestAPIEndpointType_Constants(t *testing.T) {
+	vals := []APIEndpointType{
+		APIEndpointTypePublic, APIEndpointTypePrivate, APIEndpointTypeNetworkBroker,
+	}
+	if len(vals) != 3 {
+		t.Errorf("expected 3, got %d", len(vals))
+	}
+	if string(APIEndpointTypePublic) != "PUBLIC" {
+		t.Errorf("APIEndpointTypePublic = %q", APIEndpointTypePublic)
+	}
+	if string(APIEndpointTypeNetworkBroker) != "NETWORK_BROKER" {
+		t.Errorf("APIEndpointTypeNetworkBroker = %q", APIEndpointTypeNetworkBroker)
+	}
+}
+
+func TestFileFormat_Constants(t *testing.T) {
+	vals := []FileFormat{FileFormatCSV, FileFormatJSON, FileFormatAll}
+	if len(vals) != 3 {
+		t.Errorf("expected 3, got %d", len(vals))
+	}
+	if string(FileFormatAll) != "ALL" {
+		t.Errorf("FileFormatAll = %q", FileFormatAll)
+	}
+}
+
+func TestTargetCreateRequest_NewFields_JSON(t *testing.T) {
+	req := TargetCreateRequest{
+		Name:                     "test",
+		APIEndpointType:          APIEndpointTypePrivate,
+		NetworkBrokerChannelUUID: "ch-uuid",
+		ResponseMode:             "REST",
+		SessionSupported:         true,
+		ExtraInfo:                map[string]any{"key": "val"},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded TargetCreateRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.APIEndpointType != APIEndpointTypePrivate {
+		t.Errorf("APIEndpointType = %q", decoded.APIEndpointType)
+	}
+	if decoded.NetworkBrokerChannelUUID != "ch-uuid" {
+		t.Errorf("NetworkBrokerChannelUUID = %q", decoded.NetworkBrokerChannelUUID)
+	}
+	if decoded.ResponseMode != "REST" {
+		t.Errorf("ResponseMode = %q", decoded.ResponseMode)
+	}
+	if !decoded.SessionSupported {
+		t.Error("SessionSupported should be true")
+	}
+	if decoded.ExtraInfo["key"] != "val" {
+		t.Errorf("ExtraInfo = %v", decoded.ExtraInfo)
+	}
+}
+
+func TestTargetResponse_NewFields_JSON(t *testing.T) {
+	raw := `{
+		"uuid": "tgt-1",
+		"active": true,
+		"tsg_id": "tsg-123",
+		"version": 2,
+		"profiling_status": "DONE",
+		"api_endpoint_type": "PRIVATE",
+		"response_mode": "STREAMING",
+		"session_supported": true,
+		"validated": true,
+		"secret_version": "v1",
+		"created_by_user_id": "user-1",
+		"updated_by_user_id": "user-2",
+		"extra_info": {"k": "v"}
+	}`
+	var resp TargetResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Active {
+		t.Error("Active should be true")
+	}
+	if resp.TsgID != "tsg-123" {
+		t.Errorf("TsgID = %q", resp.TsgID)
+	}
+	if resp.Version != 2 {
+		t.Errorf("Version = %d", resp.Version)
+	}
+	if resp.ProfilingStatus != "DONE" {
+		t.Errorf("ProfilingStatus = %q", resp.ProfilingStatus)
+	}
+	if resp.APIEndpointType != APIEndpointTypePrivate {
+		t.Errorf("APIEndpointType = %q", resp.APIEndpointType)
+	}
+	if resp.ResponseMode != "STREAMING" {
+		t.Errorf("ResponseMode = %q", resp.ResponseMode)
+	}
+	if !resp.SessionSupported {
+		t.Error("SessionSupported should be true")
+	}
+	if !resp.Validated {
+		t.Error("Validated should be true")
+	}
+	if resp.SecretVersion != "v1" {
+		t.Errorf("SecretVersion = %q", resp.SecretVersion)
+	}
+	if resp.CreatedByUserID != "user-1" {
+		t.Errorf("CreatedByUserID = %q", resp.CreatedByUserID)
+	}
+	if resp.UpdatedByUserID != "user-2" {
+		t.Errorf("UpdatedByUserID = %q", resp.UpdatedByUserID)
+	}
+}
+
+func TestJobResponse_NewFields_JSON(t *testing.T) {
+	raw := `{
+		"uuid": "job-1",
+		"target_id": "tgt-1",
+		"extra_info": {"k": "v"},
+		"invocation_id": "inv-1",
+		"created_by_user_id": "user-1"
+	}`
+	var resp JobResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.TargetID != "tgt-1" {
+		t.Errorf("TargetID = %q", resp.TargetID)
+	}
+	if resp.InvocationID != "inv-1" {
+		t.Errorf("InvocationID = %q", resp.InvocationID)
+	}
+	if resp.CreatedByUserID != "user-1" {
+		t.Errorf("CreatedByUserID = %q", resp.CreatedByUserID)
+	}
+	if resp.ExtraInfo["k"] != "v" {
+		t.Errorf("ExtraInfo = %v", resp.ExtraInfo)
+	}
+}
+
+func TestJobCreateRequest_NewFields_JSON(t *testing.T) {
+	v := 3
+	req := JobCreateRequest{
+		Name:      "test",
+		Target:    TargetJobRequest{UUID: "t-1"},
+		JobType:   JobTypeStatic,
+		Version:   &v,
+		ExtraInfo: map[string]any{"k": "v"},
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded JobCreateRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Version == nil || *decoded.Version != 3 {
+		t.Errorf("Version = %v", decoded.Version)
+	}
+	if decoded.ExtraInfo["k"] != "v" {
+		t.Errorf("ExtraInfo = %v", decoded.ExtraInfo)
 	}
 }

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -63,9 +63,9 @@ const (
 type APIEndpointType string
 
 const (
-	APIEndpointTypeChatCompletion APIEndpointType = "CHAT_COMPLETION"
-	APIEndpointTypeCompletion     APIEndpointType = "COMPLETION"
-	APIEndpointTypeCustom         APIEndpointType = "CUSTOM"
+	APIEndpointTypePublic        APIEndpointType = "PUBLIC"
+	APIEndpointTypePrivate       APIEndpointType = "PRIVATE"
+	APIEndpointTypeNetworkBroker APIEndpointType = "NETWORK_BROKER"
 )
 
 // RedTeamCategory represents a red team attack category.
@@ -109,9 +109,9 @@ const (
 type FileFormat string
 
 const (
-	FileFormatPDF  FileFormat = "PDF"
 	FileFormatCSV  FileFormat = "CSV"
 	FileFormatJSON FileFormat = "JSON"
+	FileFormatAll  FileFormat = "ALL"
 )
 
 // --- Pagination ---
@@ -137,6 +137,8 @@ type JobCreateRequest struct {
 	Target      TargetJobRequest `json:"target"`
 	JobType     JobType          `json:"job_type"`
 	JobMetadata map[string]any   `json:"job_metadata,omitempty"`
+	Version     *int             `json:"version,omitempty"`
+	ExtraInfo   map[string]any   `json:"extra_info,omitempty"`
 }
 
 // JobTargetResponse is the nested target info in a job response.
@@ -148,22 +150,26 @@ type JobTargetResponse struct {
 
 // JobResponse represents a red team scan job.
 type JobResponse struct {
-	UUID        string            `json:"uuid"`
-	Name        string            `json:"name,omitempty"`
-	TsgID       string            `json:"tsg_id,omitempty"`
-	Target      JobTargetResponse `json:"target,omitempty"`
-	JobType     JobType           `json:"job_type,omitempty"`
-	Status      JobStatus         `json:"status,omitempty"`
-	JobMetadata map[string]any    `json:"job_metadata,omitempty"`
-	Version     int               `json:"version,omitempty"`
-	TargetType  TargetType        `json:"target_type,omitempty"`
-	Total       int               `json:"total,omitempty"`
-	Completed   int               `json:"completed,omitempty"`
-	Score       float64           `json:"score,omitempty"`
-	ASR         float64           `json:"asr,omitempty"`
-	CreatedAt   string            `json:"created_at,omitempty"`
-	UpdatedAt   string            `json:"updated_at,omitempty"`
-	FinishedAt  string            `json:"finished_at,omitempty"`
+	UUID            string            `json:"uuid"`
+	Name            string            `json:"name,omitempty"`
+	TsgID           string            `json:"tsg_id,omitempty"`
+	Target          JobTargetResponse `json:"target,omitempty"`
+	JobType         JobType           `json:"job_type,omitempty"`
+	Status          JobStatus         `json:"status,omitempty"`
+	JobMetadata     map[string]any    `json:"job_metadata,omitempty"`
+	Version         int               `json:"version,omitempty"`
+	TargetType      TargetType        `json:"target_type,omitempty"`
+	Total           int               `json:"total,omitempty"`
+	Completed       int               `json:"completed,omitempty"`
+	Score           float64           `json:"score,omitempty"`
+	ASR             float64           `json:"asr,omitempty"`
+	CreatedAt       string            `json:"created_at,omitempty"`
+	UpdatedAt       string            `json:"updated_at,omitempty"`
+	FinishedAt      string            `json:"finished_at,omitempty"`
+	TargetID        string            `json:"target_id,omitempty"`
+	ExtraInfo       map[string]any    `json:"extra_info,omitempty"`
+	InvocationID    string            `json:"invocation_id,omitempty"`
+	CreatedByUserID string            `json:"created_by_user_id,omitempty"`
 }
 
 // JobListResponse is the paginated list of jobs.
@@ -323,14 +329,19 @@ type PropertyStatistic struct {
 
 // TargetCreateRequest is the request to create a target.
 type TargetCreateRequest struct {
-	Name             string               `json:"name"`
-	Description      string               `json:"description,omitempty"`
-	TargetType       TargetType           `json:"target_type,omitempty"`
-	ConnectionType   TargetConnectionType `json:"connection_type,omitempty"`
-	ConnectionParams map[string]any       `json:"connection_params,omitempty"`
-	Background       map[string]any       `json:"background,omitempty"`
-	Context          map[string]any       `json:"context,omitempty"`
-	Metadata         map[string]any       `json:"metadata,omitempty"`
+	Name                     string               `json:"name"`
+	Description              string               `json:"description,omitempty"`
+	TargetType               TargetType           `json:"target_type,omitempty"`
+	ConnectionType           TargetConnectionType `json:"connection_type,omitempty"`
+	ConnectionParams         map[string]any       `json:"connection_params,omitempty"`
+	Background               map[string]any       `json:"background,omitempty"`
+	Context                  map[string]any       `json:"context,omitempty"`
+	Metadata                 map[string]any       `json:"metadata,omitempty"`
+	APIEndpointType          APIEndpointType      `json:"api_endpoint_type,omitempty"`
+	NetworkBrokerChannelUUID string               `json:"network_broker_channel_uuid,omitempty"`
+	ResponseMode             string               `json:"response_mode,omitempty"`
+	SessionSupported         bool                 `json:"session_supported,omitempty"`
+	ExtraInfo                map[string]any       `json:"extra_info,omitempty"`
 }
 
 // TargetUpdateRequest is the request to update a target.
@@ -363,6 +374,18 @@ type TargetResponse struct {
 	ConnectionParams map[string]any       `json:"connection_params,omitempty"`
 	CreatedAt        string               `json:"created_at,omitempty"`
 	UpdatedAt        string               `json:"updated_at,omitempty"`
+	Active           bool                 `json:"active,omitempty"`
+	TsgID            string               `json:"tsg_id,omitempty"`
+	Version          int                  `json:"version,omitempty"`
+	ProfilingStatus  string               `json:"profiling_status,omitempty"`
+	APIEndpointType  APIEndpointType      `json:"api_endpoint_type,omitempty"`
+	ResponseMode     string               `json:"response_mode,omitempty"`
+	SessionSupported bool                 `json:"session_supported,omitempty"`
+	Validated        bool                 `json:"validated,omitempty"`
+	SecretVersion    string               `json:"secret_version,omitempty"`
+	CreatedByUserID  string               `json:"created_by_user_id,omitempty"`
+	UpdatedByUserID  string               `json:"updated_by_user_id,omitempty"`
+	ExtraInfo        map[string]any       `json:"extra_info,omitempty"`
 }
 
 // TargetList is the paginated list of targets.

--- a/aisec/scan/models.go
+++ b/aisec/scan/models.go
@@ -74,8 +74,8 @@ type ScanResponse struct {
 	ResponseDetected         *ResponseDetected `json:"response_detected,omitempty"`
 	PromptMaskedData         *MaskedData       `json:"prompt_masked_data,omitempty"`
 	ResponseMaskedData       *MaskedData       `json:"response_masked_data,omitempty"`
-	PromptDetectionDetails   map[string]any    `json:"prompt_detection_details,omitempty"`
-	ResponseDetectionDetails map[string]any    `json:"response_detection_details,omitempty"`
+	PromptDetectionDetails   *DetectionDetails `json:"prompt_detection_details,omitempty"`
+	ResponseDetectionDetails *DetectionDetails `json:"response_detection_details,omitempty"`
 	ToolDetected             *ToolDetected     `json:"tool_detected,omitempty"`
 	CreatedAt                string            `json:"created_at,omitempty"`
 	CompletedAt              string            `json:"completed_at,omitempty"`
@@ -173,6 +173,11 @@ type TopicGuardRails struct {
 	BlockedTopics []string `json:"blocked_topics,omitempty"`
 }
 
+// DetectionDetails holds detection details for prompt/response.
+type DetectionDetails struct {
+	TopicGuardrailsDetails *TopicGuardRails `json:"topic_guardrails_details,omitempty"`
+}
+
 // ToolDetectionDetails holds additional detection details.
 type ToolDetectionDetails struct {
 	TopicGuardrailsDetails *TopicGuardRails `json:"topic_guardrails_details,omitempty"`
@@ -242,17 +247,27 @@ type DSResultMetadata struct {
 
 // UrlfEntry is a URL filter report entry.
 type UrlfEntry struct {
-	URL       string `json:"url,omitempty"`
-	RiskLevel string `json:"risk_level,omitempty"`
-	Action    string `json:"action,omitempty"`
+	URL        string   `json:"url,omitempty"`
+	RiskLevel  string   `json:"risk_level,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Categories []string `json:"categories,omitempty"`
+}
+
+// DlpPatternDetections holds pattern detection offsets for DLP.
+type DlpPatternDetections struct {
+	Pattern          string  `json:"pattern,omitempty"`
+	DetectionOffsets [][]int `json:"detection_offsets,omitempty"`
 }
 
 // DlpReport holds DLP detection report details.
 type DlpReport struct {
-	DlpReportID       string `json:"dlp_report_id,omitempty"`
-	DlpProfileName    string `json:"dlp_profile_name,omitempty"`
-	DlpProfileID      string `json:"dlp_profile_id,omitempty"`
-	DlpProfileVersion int    `json:"dlp_profile_version,omitempty"`
+	DlpReportID                 string                 `json:"dlp_report_id,omitempty"`
+	DlpProfileName              string                 `json:"dlp_profile_name,omitempty"`
+	DlpProfileID                string                 `json:"dlp_profile_id,omitempty"`
+	DlpProfileVersion           int                    `json:"dlp_profile_version,omitempty"`
+	DataPatternRule1Verdict     string                 `json:"data_pattern_rule1_verdict,omitempty"`
+	DataPatternRule2Verdict     string                 `json:"data_pattern_rule2_verdict,omitempty"`
+	DataPatternDetectionOffsets []DlpPatternDetections `json:"data_pattern_detection_offsets,omitempty"`
 }
 
 // DbsEntry is a database security report entry.
@@ -270,23 +285,34 @@ type TcReport struct {
 
 // McEntry is a malicious code analysis entry.
 type McEntry struct {
-	CodeType string `json:"code_type,omitempty"`
-	Verdict  string `json:"verdict,omitempty"`
-	Action   string `json:"action,omitempty"`
+	FileType   string `json:"file_type,omitempty"`
+	CodeSha256 string `json:"code_sha256,omitempty"`
+}
+
+// MalwareReport holds malware script report details.
+type MalwareReport struct {
+	Verdict string `json:"verdict,omitempty"`
+}
+
+// CmdEntry is a command injection report entry.
+type CmdEntry struct {
+	CodeBlock string `json:"code_block,omitempty"`
+	Verdict   string `json:"verdict,omitempty"`
 }
 
 // McReport holds malicious code report details.
 type McReport struct {
-	AllCodeBlocks       []string       `json:"all_code_blocks,omitempty"`
-	CodeAnalysisByType  []McEntry      `json:"code_analysis_by_type,omitempty"`
-	Verdict             string         `json:"verdict,omitempty"`
-	MalwareScriptReport map[string]any `json:"malware_script_report,omitempty"`
+	AllCodeBlocks          []string       `json:"all_code_blocks,omitempty"`
+	CodeAnalysisByType     []McEntry      `json:"code_analysis_by_type,omitempty"`
+	Verdict                string         `json:"verdict,omitempty"`
+	MalwareScriptReport    *MalwareReport `json:"malware_script_report,omitempty"`
+	CommandInjectionReport []CmdEntry     `json:"command_injection_report,omitempty"`
 }
 
 // AgentEntry is an agent detection pattern entry.
 type AgentEntry struct {
-	Pattern string `json:"pattern,omitempty"`
-	Verdict string `json:"verdict,omitempty"`
+	CategoryType string `json:"category_type,omitempty"`
+	Verdict      string `json:"verdict,omitempty"`
 }
 
 // AgentReport holds agent detection report details.
@@ -338,7 +364,7 @@ type ThreatScanReport struct {
 	Source           string                   `json:"source,omitempty"`
 	ReportID         string                   `json:"report_id,omitempty"`
 	ScanID           string                   `json:"scan_id,omitempty"`
-	ReqID            int                      `json:"req_id,omitempty"`
+	ReqID            uint32                   `json:"req_id,omitempty"`
 	TransactionID    string                   `json:"transaction_id,omitempty"`
 	SessionID        string                   `json:"session_id,omitempty"`
 	DetectionResults []DetectionServiceResult `json:"detection_results,omitempty"`

--- a/aisec/scan/scanner_test.go
+++ b/aisec/scan/scanner_test.go
@@ -454,6 +454,196 @@ func TestDetectionServiceResult_JSONFormat(t *testing.T) {
 	}
 }
 
+func TestMcEntry_JSONFormat(t *testing.T) {
+	entry := McEntry{FileType: "python", CodeSha256: "abc123"}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["file_type"] != "python" {
+		t.Errorf("file_type = %v", decoded["file_type"])
+	}
+	if decoded["code_sha256"] != "abc123" {
+		t.Errorf("code_sha256 = %v", decoded["code_sha256"])
+	}
+	if decoded["code_type"] != nil {
+		t.Error("code_type should not exist")
+	}
+	if decoded["verdict"] != nil {
+		t.Error("verdict should not exist on McEntry")
+	}
+	if decoded["action"] != nil {
+		t.Error("action should not exist on McEntry")
+	}
+}
+
+func TestAgentEntry_JSONFormat(t *testing.T) {
+	entry := AgentEntry{CategoryType: "prompt_injection", Verdict: "malicious"}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["category_type"] != "prompt_injection" {
+		t.Errorf("category_type = %v", decoded["category_type"])
+	}
+	if decoded["verdict"] != "malicious" {
+		t.Errorf("verdict = %v", decoded["verdict"])
+	}
+	if decoded["pattern"] != nil {
+		t.Error("pattern should not exist on AgentEntry")
+	}
+}
+
+func TestUrlfEntry_JSONFormat(t *testing.T) {
+	entry := UrlfEntry{
+		URL:        "http://example.com",
+		RiskLevel:  "high",
+		Action:     "block",
+		Categories: []string{"malware", "phishing"},
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	cats, ok := decoded["categories"].([]any)
+	if !ok || len(cats) != 2 {
+		t.Fatalf("categories = %v", decoded["categories"])
+	}
+	if cats[0] != "malware" {
+		t.Errorf("categories[0] = %v", cats[0])
+	}
+}
+
+func TestDlpReport_JSONFormat(t *testing.T) {
+	report := DlpReport{
+		DlpReportID:             "rpt-1",
+		DataPatternRule1Verdict: "hit",
+		DataPatternRule2Verdict: "miss",
+		DataPatternDetectionOffsets: []DlpPatternDetections{
+			{Pattern: "SSN", DetectionOffsets: [][]int{{0, 11}}},
+		},
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded["data_pattern_rule1_verdict"] != "hit" {
+		t.Errorf("data_pattern_rule1_verdict = %v", decoded["data_pattern_rule1_verdict"])
+	}
+	if decoded["data_pattern_rule2_verdict"] != "miss" {
+		t.Errorf("data_pattern_rule2_verdict = %v", decoded["data_pattern_rule2_verdict"])
+	}
+	offsets, ok := decoded["data_pattern_detection_offsets"].([]any)
+	if !ok || len(offsets) != 1 {
+		t.Fatalf("data_pattern_detection_offsets = %v", decoded["data_pattern_detection_offsets"])
+	}
+}
+
+func TestMcReport_WithCmdInjection(t *testing.T) {
+	report := McReport{
+		Verdict:             "malicious",
+		MalwareScriptReport: &MalwareReport{Verdict: "malicious"},
+		CommandInjectionReport: []CmdEntry{
+			{CodeBlock: "rm -rf /", Verdict: "malicious"},
+		},
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	cmds, ok := decoded["command_injection_report"].([]any)
+	if !ok || len(cmds) != 1 {
+		t.Fatalf("command_injection_report = %v", decoded["command_injection_report"])
+	}
+	malware, ok := decoded["malware_script_report"].(map[string]any)
+	if !ok {
+		t.Fatal("malware_script_report should be an object")
+	}
+	if malware["verdict"] != "malicious" {
+		t.Errorf("malware_script_report.verdict = %v", malware["verdict"])
+	}
+}
+
+func TestDetectionDetails_JSONFormat(t *testing.T) {
+	resp := ScanResponse{
+		ScanID:   "scan-1",
+		ReportID: "rpt-1",
+		Category: "benign",
+		Action:   "allow",
+		PromptDetectionDetails: &DetectionDetails{
+			TopicGuardrailsDetails: &TopicGuardRails{
+				AllowedTopics: []string{"general"},
+				BlockedTopics: []string{"violence"},
+			},
+		},
+		ResponseDetectionDetails: &DetectionDetails{
+			TopicGuardrailsDetails: &TopicGuardRails{
+				BlockedTopics: []string{"pii"},
+			},
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	pdd, ok := decoded["prompt_detection_details"].(map[string]any)
+	if !ok {
+		t.Fatal("prompt_detection_details should be an object")
+	}
+	tgd, ok := pdd["topic_guardrails_details"].(map[string]any)
+	if !ok {
+		t.Fatal("topic_guardrails_details should be an object")
+	}
+	allowed, ok := tgd["allowed_topics"].([]any)
+	if !ok || len(allowed) != 1 || allowed[0] != "general" {
+		t.Errorf("allowed_topics = %v", tgd["allowed_topics"])
+	}
+
+	rdd, ok := decoded["response_detection_details"].(map[string]any)
+	if !ok {
+		t.Fatal("response_detection_details should be an object")
+	}
+	if rdd["topic_guardrails_details"] == nil {
+		t.Error("response_detection_details missing topic_guardrails_details")
+	}
+}
+
 func TestToolDetected_FullRoundTrip(t *testing.T) {
 	td := ToolDetected{
 		Verdict: "malicious",


### PR DESCRIPTION
## Summary
Closes #36

Post-alignment audit found remaining discrepancies between OpenAPI specs and Go models across all 4 packages. This PR fixes them all.

### Scan
- Fix McEntry: `code_type`→`file_type`, add `code_sha256`, remove wrong `verdict`/`action`
- Fix AgentEntry: `pattern`→`category_type`
- Add `categories` to UrlfEntry
- Add 3 missing fields to DlpReport
- Add new types: MalwareReport, CmdEntry, DlpPatternDetections, DetectionDetails
- Add `command_injection_report` to McReport, type `malware_script_report`
- Type PromptDetectionDetails/ResponseDetectionDetails (was `map[string]any`)
- Fix ThreatScanReport.ReqID: `int`→`uint32`

### Management
- Add Revision + audit fields to SecurityProfile/CustomTopic
- Expand CreateApiKeyRequest with all 7 required spec fields
- Fix CustomerApp structure (customer_appId, tsg_id, cloud_provider, etc.)
- Fix DeploymentProfile (ave_text_records replaces monthly_billion_tokens)

### ModelSecurity
- Add 16 ErrorCode enum constants
- Add 30 ThreatCategory enum constants
- Fix LabelsResponse
- Remove invalid SortBy param from ScanListOpts

### RedTeam
- Fix APIEndpointType enum (PUBLIC/PRIVATE/NETWORK_BROKER)
- Fix FileFormat enum (remove PDF, add ALL)
- Expand TargetCreateRequest/Response with missing spec fields
- Expand JobResponse/CreateRequest with missing fields

## Test plan
- [x] JSON round-trip tests for all changed types (6 new scan, 3 management, 4 modelsecurity, 4 redteam)
- [x] Enum constant tests
- [x] `go test -race ./...` all pass
- [x] `gofmt` and `go vet` clean