### PR TITLE
feat(modelsecurity): add SortByFileField enum (#43)

### DIFF
--- a/aisec/modelsecurity/client_test.go
+++ b/aisec/modelsecurity/client_test.go
@@ -773,3 +773,12 @@ func TestBuildGroupListParams_SourceTypesAndEnabledRules(t *testing.T) {
 		t.Errorf("enabled_rules = %q", params["enabled_rules"])
 	}
 }
+
+func TestSortByFileField_Values(t *testing.T) {
+	if SortByFileFieldPath != SortByFileField("path") {
+		t.Errorf("SortByFileFieldPath = %q", SortByFileFieldPath)
+	}
+	if SortByFileFieldType != SortByFileField("type") {
+		t.Errorf("SortByFileFieldType = %q", SortByFileFieldType)
+	}
+}

--- a/aisec/modelsecurity/models.go
+++ b/aisec/modelsecurity/models.go
@@ -103,6 +103,14 @@ const (
 	SortDirectionDesc SortDirection = "desc"
 )
 
+// SortByFileField represents sortable file fields.
+type SortByFileField string
+
+const (
+	SortByFileFieldPath SortByFileField = "path"
+	SortByFileFieldType SortByFileField = "type"
+)
+
 // RuleEditableFieldType represents editable field types.
 type RuleEditableFieldType string
 


### PR DESCRIPTION
## Summary
- Add `SortByFileField` enum type with `path` and `type` values per `model-service.yaml` spec
- Audited all nullable fields — `omitempty` tags already correct

## Changes
- `aisec/modelsecurity/models.go`: add `SortByFileField` type + 2 constants
- `aisec/modelsecurity/client_test.go`: add enum value test

## Testing
- 1 new test
- All quality gates pass (`make check`)

## Checklist
- [x] Tests written first (TDD)
- [x] All tests passing
- [x] Linting clean
- [x] Formatting clean

Closes #43