### PR TITLE
feat(redteam): comprehensive spec alignment with OpenAPI definitions

### DIFF
--- a/aisec/redteam/client_test.go
+++ b/aisec/redteam/client_test.go
@@ -156,7 +156,7 @@ func TestScans_GetCategories(t *testing.T) {
 
 func TestReports_GetStaticReport(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(StaticJobReport{JobID: "job-1"})
+		_ = json.NewEncoder(w).Encode(StaticJobReport{ReportSummary: "job-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -166,14 +166,14 @@ func TestReports_GetStaticReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rpt.JobID != "job-1" {
-		t.Errorf("JobID = %q", rpt.JobID)
+	if rpt.ReportSummary != "job-1" {
+		t.Errorf("ReportSummary = %q", rpt.ReportSummary)
 	}
 }
 
 func TestReports_GetDynamicReport(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(DynamicJobReport{JobID: "job-1"})
+		_ = json.NewEncoder(w).Encode(DynamicJobReport{ReportSummary: "job-1", TotalGoals: 5})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -183,8 +183,8 @@ func TestReports_GetDynamicReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rpt.JobID != "job-1" {
-		t.Errorf("JobID = %q", rpt.JobID)
+	if rpt.ReportSummary != "job-1" {
+		t.Errorf("ReportSummary = %q", rpt.ReportSummary)
 	}
 }
 
@@ -211,7 +211,7 @@ func TestReports_ListAttacks(t *testing.T) {
 func TestReports_ListGoals(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(GoalListResponse{
-			Items:      []Goal{{ID: "goal-1"}},
+			Items:      []Goal{{UUID: "goal-1"}},
 			Pagination: RedTeamPagination{Total: 1},
 		})
 	})
@@ -512,7 +512,7 @@ func TestCustomAttacks_GetPropertyNames(t *testing.T) {
 
 func TestGetScanStatistics(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(ScanStatisticsResponse{Stats: map[string]any{"total": 10}})
+		_ = json.NewEncoder(w).Encode(ScanStatisticsResponse{TotalScans: 10, TargetsScanned: 5})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -522,14 +522,14 @@ func TestGetScanStatistics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Stats["total"] == nil {
-		t.Error("missing stats")
+	if stats.TotalScans != 10 {
+		t.Errorf("TotalScans = %d", stats.TotalScans)
 	}
 }
 
 func TestGetQuota(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(QuotaSummary{Details: map[string]any{"used": 5}})
+		_ = json.NewEncoder(w).Encode(QuotaSummary{StaticQuota: 100, StaticUsed: 50})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -539,8 +539,8 @@ func TestGetQuota(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if quota.Details["used"] == nil {
-		t.Error("missing quota details")
+	if quota.StaticQuota != 100 {
+		t.Errorf("StaticQuota = %d", quota.StaticQuota)
 	}
 }
 
@@ -653,7 +653,7 @@ func TestReports_GetAttackDetail(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("method = %s", r.Method)
 		}
-		_ = json.NewEncoder(w).Encode(AttackDetailResponse{ID: "a-1", Category: "injection"})
+		_ = json.NewEncoder(w).Encode(AttackDetailResponse{UUID: "a-1", Category: "injection"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -663,14 +663,14 @@ func TestReports_GetAttackDetail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.ID != "a-1" {
-		t.Errorf("ID = %q", resp.ID)
+	if resp.UUID != "a-1" {
+		t.Errorf("UUID = %q", resp.UUID)
 	}
 }
 
 func TestReports_GetMultiTurnAttackDetail(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(AttackMultiTurnDetailResponse{ID: "a-1", Category: "injection"})
+		_ = json.NewEncoder(w).Encode(AttackMultiTurnDetailResponse{UUID: "a-1"})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -680,8 +680,8 @@ func TestReports_GetMultiTurnAttackDetail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.ID != "a-1" {
-		t.Errorf("ID = %q", resp.ID)
+	if resp.UUID != "a-1" {
+		t.Errorf("UUID = %q", resp.UUID)
 	}
 }
 
@@ -933,7 +933,7 @@ func TestCustomAttackReports_GetPropertyStats(t *testing.T) {
 
 func TestGetScoreTrend(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(ScoreTrendResponse{TargetID: "t-1"})
+		_ = json.NewEncoder(w).Encode(ScoreTrendResponse{Labels: []string{"2025-01"}})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -943,15 +943,15 @@ func TestGetScoreTrend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.TargetID != "t-1" {
-		t.Errorf("TargetID = %q", resp.TargetID)
+	if len(resp.Labels) != 1 {
+		t.Errorf("Labels = %v", resp.Labels)
 	}
 }
 
 func TestGetErrorLogs(t *testing.T) {
 	tokenSrv, apiSrv := newTestServers(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ErrorLogListResponse{
-			Items:      []map[string]any{{"id": "e-1"}},
+			Items:      []ErrorLog{{JobID: "e-1"}},
 			Pagination: RedTeamPagination{Total: 1},
 		})
 	})
@@ -1451,7 +1451,7 @@ func TestCustomPromptResponse_JSON(t *testing.T) {
 		"prompt_set_id": "ps-1",
 		"prompt": "test",
 		"goal": "a goal",
-		"user_defined_goal": "user goal",
+		"user_defined_goal": true,
 		"detector_category": "security",
 		"severity": "HIGH",
 		"active": true
@@ -1472,8 +1472,8 @@ func TestCustomPromptResponse_JSON(t *testing.T) {
 	if resp.Goal != "a goal" {
 		t.Errorf("Goal = %q", resp.Goal)
 	}
-	if resp.UserDefinedGoal != "user goal" {
-		t.Errorf("UserDefinedGoal = %q", resp.UserDefinedGoal)
+	if !resp.UserDefinedGoal {
+		t.Error("UserDefinedGoal should be true")
 	}
 	if resp.DetectorCategory != "security" {
 		t.Errorf("DetectorCategory = %q", resp.DetectorCategory)

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -114,6 +114,168 @@ const (
 	FileFormatAll  FileFormat = "ALL"
 )
 
+// AttackStatus represents the status of an individual attack.
+type AttackStatus string
+
+const (
+	AttackStatusInit      AttackStatus = "INIT"
+	AttackStatusAttack    AttackStatus = "ATTACK"
+	AttackStatusDetection AttackStatus = "DETECTION"
+	AttackStatusReport    AttackStatus = "REPORT"
+	AttackStatusCompleted AttackStatus = "COMPLETED"
+	AttackStatusFailed    AttackStatus = "FAILED"
+)
+
+// AttackType represents the type of an attack.
+type AttackType string
+
+const (
+	AttackTypeNormal AttackType = "NORMAL"
+	AttackTypeCustom AttackType = "CUSTOM"
+)
+
+// AuthType represents authentication type for targets.
+type AuthType string
+
+const (
+	AuthTypeOAuth       AuthType = "OAUTH"
+	AuthTypeAccessToken AuthType = "ACCESS_TOKEN"
+)
+
+// BrandSubCategory represents brand attack sub-categories.
+type BrandSubCategory string
+
+const (
+	BrandSubCategoryCompetitorEndorsements BrandSubCategory = "COMPETITOR_ENDORSEMENTS"
+	BrandSubCategoryBrandTarnishing        BrandSubCategory = "BRAND_TARNISHING_SELF_CRITICISM"
+	BrandSubCategoryDiscriminatingClaims   BrandSubCategory = "DISCRIMINATING_CLAIMS"
+	BrandSubCategoryPoliticalEndorsements  BrandSubCategory = "POLITICAL_ENDORSEMENTS"
+)
+
+// ComplianceSubCategory represents compliance attack sub-categories.
+type ComplianceSubCategory string
+
+const (
+	ComplianceSubCategoryOWASP      ComplianceSubCategory = "OWASP"
+	ComplianceSubCategoryMITREATLAS ComplianceSubCategory = "MITRE_ATLAS"
+	ComplianceSubCategoryNIST       ComplianceSubCategory = "NIST"
+	ComplianceSubCategoryDASFV2     ComplianceSubCategory = "DASF_V2"
+)
+
+// SafetySubCategory represents safety attack sub-categories.
+type SafetySubCategory string
+
+const (
+	SafetySubCategoryBias                 SafetySubCategory = "BIAS"
+	SafetySubCategoryCBRN                 SafetySubCategory = "CBRN"
+	SafetySubCategoryCybercrime           SafetySubCategory = "CYBERCRIME"
+	SafetySubCategoryDrugs                SafetySubCategory = "DRUGS"
+	SafetySubCategoryHateToxicAbuse       SafetySubCategory = "HATE_TOXIC_ABUSE"
+	SafetySubCategoryNonViolentCrimes     SafetySubCategory = "NON_VIOLENT_CRIMES"
+	SafetySubCategoryPolitical            SafetySubCategory = "POLITICAL"
+	SafetySubCategorySelfHarm             SafetySubCategory = "SELF_HARM"
+	SafetySubCategorySexual               SafetySubCategory = "SEXUAL"
+	SafetySubCategoryViolentCrimesWeapons SafetySubCategory = "VIOLENT_CRIMES_WEAPONS"
+)
+
+// SecuritySubCategory represents security attack sub-categories.
+type SecuritySubCategory string
+
+const (
+	SecuritySubCategoryAdversarialSuffix       SecuritySubCategory = "ADVERSARIAL_SUFFIX"
+	SecuritySubCategoryEvasion                 SecuritySubCategory = "EVASION"
+	SecuritySubCategoryIndirectPromptInjection SecuritySubCategory = "INDIRECT_PROMPT_INJECTION"
+	SecuritySubCategoryJailbreak               SecuritySubCategory = "JAILBREAK"
+	SecuritySubCategoryMultiTurn               SecuritySubCategory = "MULTI_TURN"
+	SecuritySubCategoryPromptInjection         SecuritySubCategory = "PROMPT_INJECTION"
+	SecuritySubCategoryRemoteCodeExecution     SecuritySubCategory = "REMOTE_CODE_EXECUTION"
+	SecuritySubCategorySystemPromptLeak        SecuritySubCategory = "SYSTEM_PROMPT_LEAK"
+	SecuritySubCategoryToolLeak                SecuritySubCategory = "TOOL_LEAK"
+	SecuritySubCategoryMalwareGeneration       SecuritySubCategory = "MALWARE_GENERATION"
+)
+
+// ErrorSource represents the source of an error log.
+type ErrorSource string
+
+const (
+	ErrorSourceTarget          ErrorSource = "TARGET"
+	ErrorSourceJob             ErrorSource = "JOB"
+	ErrorSourceSystem          ErrorSource = "SYSTEM"
+	ErrorSourceValidation      ErrorSource = "VALIDATION"
+	ErrorSourceTargetProfiling ErrorSource = "TARGET_PROFILING"
+)
+
+// ErrorTypeEnum represents the type of an error log.
+type ErrorTypeEnum string
+
+const (
+	ErrorTypeContentFilter  ErrorTypeEnum = "CONTENT_FILTER"
+	ErrorTypeRateLimit      ErrorTypeEnum = "RATE_LIMIT"
+	ErrorTypeAuthentication ErrorTypeEnum = "AUTHENTICATION"
+	ErrorTypeNetwork        ErrorTypeEnum = "NETWORK"
+	ErrorTypeValidation     ErrorTypeEnum = "VALIDATION"
+	ErrorTypeNetworkChannel ErrorTypeEnum = "NETWORK_CHANNEL"
+	ErrorTypeUnknown        ErrorTypeEnum = "UNKNOWN"
+)
+
+// ProfilingStatus represents the profiling status of a target.
+type ProfilingStatus string
+
+const (
+	ProfilingStatusInit       ProfilingStatus = "INIT"
+	ProfilingStatusQueued     ProfilingStatus = "QUEUED"
+	ProfilingStatusInProgress ProfilingStatus = "IN_PROGRESS"
+	ProfilingStatusCompleted  ProfilingStatus = "COMPLETED"
+	ProfilingStatusFailed     ProfilingStatus = "FAILED"
+)
+
+// StreamType represents the type of a conversation stream.
+type StreamType string
+
+const (
+	StreamTypeNormal      StreamType = "NORMAL"
+	StreamTypeAdversarial StreamType = "ADVERSARIAL"
+)
+
+// PolicyType represents runtime policy types.
+type PolicyType string
+
+const (
+	PolicyTypePromptInjection         PolicyType = "PROMPT_INJECTION"
+	PolicyTypeToxicContent            PolicyType = "TOXIC_CONTENT"
+	PolicyTypeCustomTopicGuardrails   PolicyType = "CUSTOM_TOPIC_GUARDRAILS"
+	PolicyTypeMaliciousCodeDetection  PolicyType = "MALICIOUS_CODE_DETECTION"
+	PolicyTypeMaliciousURLDetection   PolicyType = "MALICIOUS_URL_DETECTION"
+	PolicyTypeSensitiveDataProtection PolicyType = "SENSITIVE_DATA_PROTECTION"
+)
+
+// GuardrailAction represents a guardrail action.
+type GuardrailAction string
+
+const (
+	GuardrailActionAllow GuardrailAction = "ALLOW"
+	GuardrailActionBlock GuardrailAction = "BLOCK"
+)
+
+// DateRangeFilter represents date range filter options.
+type DateRangeFilter string
+
+const (
+	DateRangeFilterLast7Days  DateRangeFilter = "LAST_7_DAYS"
+	DateRangeFilterLast15Days DateRangeFilter = "LAST_15_DAYS"
+	DateRangeFilterLast30Days DateRangeFilter = "LAST_30_DAYS"
+	DateRangeFilterAll        DateRangeFilter = "ALL"
+)
+
+// CountedQuotaEnum represents quota counting status.
+type CountedQuotaEnum string
+
+const (
+	CountedQuotaHeld       CountedQuotaEnum = "HELD"
+	CountedQuotaCounted    CountedQuotaEnum = "COUNTED"
+	CountedQuotaNotCounted CountedQuotaEnum = "NOT_COUNTED"
+)
+
 // --- Pagination ---
 
 // RedTeamPagination holds pagination metadata.
@@ -200,18 +362,42 @@ type SubCategory struct {
 
 // --- Report types ---
 
+// SeverityReport holds severity-level counts.
+type SeverityReport struct {
+	Low      int `json:"low"`
+	Medium   int `json:"medium"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
+}
+
+// CategoryReport holds per-category report data.
+type CategoryReport struct {
+	Category      string         `json:"category,omitempty"`
+	SubCategories map[string]any `json:"sub_categories,omitempty"`
+}
+
 // StaticJobReport represents a static scan report.
 type StaticJobReport struct {
-	JobID   string         `json:"job_id,omitempty"`
-	Stats   map[string]any `json:"stats,omitempty"`
-	Details map[string]any `json:"details,omitempty"`
+	ASR              *float64         `json:"asr,omitempty"`
+	Score            *float64         `json:"score,omitempty"`
+	SecurityReport   *CategoryReport  `json:"security_report,omitempty"`
+	SafetyReport     *CategoryReport  `json:"safety_report,omitempty"`
+	BrandReport      *CategoryReport  `json:"brand_report,omitempty"`
+	ComplianceReport []map[string]any `json:"compliance_report,omitempty"`
+	SeverityReport   *SeverityReport  `json:"severity_report,omitempty"`
+	ReportSummary    string           `json:"report_summary,omitempty"`
+	Recommendations  map[string]any   `json:"recommendations,omitempty"`
 }
 
 // DynamicJobReport represents a dynamic scan report.
 type DynamicJobReport struct {
-	JobID   string         `json:"job_id,omitempty"`
-	Stats   map[string]any `json:"stats,omitempty"`
-	Details map[string]any `json:"details,omitempty"`
+	TotalGoals    int     `json:"total_goals"`
+	TotalStreams  int     `json:"total_streams"`
+	TotalThreats  int     `json:"total_threats"`
+	GoalsAchieved int     `json:"goals_achieved"`
+	ReportSummary string  `json:"report_summary,omitempty"`
+	Score         float64 `json:"score"`
+	ASR           float64 `json:"asr"`
 }
 
 // ReportDownloadResponse wraps raw bytes from a report download.
@@ -236,17 +422,44 @@ type AttackListResponse struct {
 
 // AttackDetailResponse represents detailed attack information.
 type AttackDetailResponse struct {
-	ID       string         `json:"id,omitempty"`
-	Category string         `json:"category,omitempty"`
-	Severity string         `json:"severity,omitempty"`
-	Details  map[string]any `json:"details,omitempty"`
+	UUID                   string           `json:"uuid,omitempty"`
+	TsgID                  string           `json:"tsg_id,omitempty"`
+	JobID                  string           `json:"job_id,omitempty"`
+	TargetID               string           `json:"target_id,omitempty"`
+	Prompt                 string           `json:"prompt,omitempty"`
+	Status                 string           `json:"status,omitempty"`
+	MarkedSafe             *bool            `json:"marked_safe,omitempty"`
+	Threat                 *bool            `json:"threat,omitempty"`
+	AttackType             string           `json:"attack_type,omitempty"`
+	MultiTurn              bool             `json:"multi_turn,omitempty"`
+	ASR                    *float64         `json:"asr,omitempty"`
+	Version                *int             `json:"version,omitempty"`
+	PromptMappingID        string           `json:"prompt_mapping_id,omitempty"`
+	PromptID               string           `json:"prompt_id,omitempty"`
+	Category               string           `json:"category,omitempty"`
+	SubCategory            string           `json:"sub_category,omitempty"`
+	Severity               string           `json:"severity,omitempty"`
+	CategoryDisplayName    string           `json:"category_display_name,omitempty"`
+	SubCategoryDisplayName string           `json:"sub_category_display_name,omitempty"`
+	ComplianceFrameworks   []string         `json:"compliance_frameworks,omitempty"`
+	Outputs                []map[string]any `json:"outputs,omitempty"`
+	Goal                   map[string]any   `json:"goal,omitempty"`
 }
 
 // AttackMultiTurnDetailResponse represents multi-turn attack detail.
 type AttackMultiTurnDetailResponse struct {
-	ID       string         `json:"id,omitempty"`
-	Category string         `json:"category,omitempty"`
-	Details  map[string]any `json:"details,omitempty"`
+	UUID       string `json:"uuid,omitempty"`
+	TsgID      string `json:"tsg_id,omitempty"`
+	AttackID   string `json:"attack_id,omitempty"`
+	JobID      string `json:"job_id,omitempty"`
+	TargetID   string `json:"target_id,omitempty"`
+	Prompt     string `json:"prompt,omitempty"`
+	Output     string `json:"output,omitempty"`
+	Threat     *bool  `json:"threat,omitempty"`
+	MarkedSafe *bool  `json:"marked_safe,omitempty"`
+	Turn       int    `json:"turn,omitempty"`
+	Generation int    `json:"generation,omitempty"`
+	MultiTurn  bool   `json:"multi_turn,omitempty"`
 }
 
 // RemediationResponse is the remediation advice response.
@@ -269,10 +482,20 @@ type GoalListResponse struct {
 
 // Goal represents a dynamic red team goal.
 type Goal struct {
-	ID       string         `json:"id,omitempty"`
-	GoalType GoalType       `json:"goal_type,omitempty"`
-	Status   string         `json:"status,omitempty"`
-	Details  map[string]any `json:"details,omitempty"`
+	UUID               string         `json:"uuid,omitempty"`
+	GoalType           GoalType       `json:"goal_type,omitempty"`
+	Status             string         `json:"status,omitempty"`
+	Goal               string         `json:"goal,omitempty"`
+	SafeResponse       string         `json:"safe_response,omitempty"`
+	JailbrokenResponse string         `json:"jailbroken_response,omitempty"`
+	GoalMetadata       map[string]any `json:"goal_metadata,omitempty"`
+	CustomGoal         bool           `json:"custom_goal,omitempty"`
+	TsgID              string         `json:"tsg_id,omitempty"`
+	JobID              string         `json:"job_id,omitempty"`
+	GoalToShow         string         `json:"goal_to_show,omitempty"`
+	Threat             *bool          `json:"threat,omitempty"`
+	Version            *int           `json:"version,omitempty"`
+	ExtraInfo          map[string]any `json:"extra_info,omitempty"`
 }
 
 // StreamListResponse is the paginated list of streams.
@@ -447,15 +670,20 @@ type CustomPromptSetArchiveRequest struct {
 
 // CustomPromptSetResponse represents a custom prompt set.
 type CustomPromptSetResponse struct {
-	UUID        string         `json:"uuid"`
-	Name        string         `json:"name,omitempty"`
-	Description string         `json:"description,omitempty"`
-	Status      string         `json:"status,omitempty"`
-	Active      bool           `json:"active,omitempty"`
-	Archive     bool           `json:"archive,omitempty"`
-	Stats       map[string]any `json:"stats,omitempty"`
-	CreatedAt   string         `json:"created_at,omitempty"`
-	UpdatedAt   string         `json:"updated_at,omitempty"`
+	UUID            string         `json:"uuid"`
+	Name            string         `json:"name,omitempty"`
+	Description     string         `json:"description,omitempty"`
+	Version         string         `json:"version,omitempty"`
+	Status          string         `json:"status,omitempty"`
+	Active          bool           `json:"active,omitempty"`
+	Archive         bool           `json:"archive,omitempty"`
+	Stats           map[string]any `json:"stats,omitempty"`
+	ExtraInfo       map[string]any `json:"extra_info,omitempty"`
+	PropertyNames   []string       `json:"property_names,omitempty"`
+	CreatedAt       string         `json:"created_at,omitempty"`
+	UpdatedAt       string         `json:"updated_at,omitempty"`
+	CreatedByUserID string         `json:"created_by_user_id,omitempty"`
+	UpdatedByUserID string         `json:"updated_by_user_id,omitempty"`
 }
 
 // CustomPromptSetList is the paginated list of prompt sets.
@@ -471,8 +699,14 @@ type CustomPromptSetListActive struct {
 
 // CustomPromptSetReference is the reference for a prompt set.
 type CustomPromptSetReference struct {
-	UUID      string         `json:"uuid,omitempty"`
-	Reference map[string]any `json:"reference,omitempty"`
+	UUID      string `json:"uuid,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Active    bool   `json:"active,omitempty"`
+	TsgID     string `json:"tsg_id,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
 // CustomPromptSetVersionInfo is the version info for a prompt set.
@@ -498,16 +732,20 @@ type CustomPromptUpdateRequest struct {
 
 // CustomPromptResponse represents a custom prompt.
 type CustomPromptResponse struct {
-	UUID             string         `json:"uuid"`
-	PromptSetID      string         `json:"prompt_set_id,omitempty"`
-	Prompt           string         `json:"prompt,omitempty"`
-	Goal             string         `json:"goal,omitempty"`
-	UserDefinedGoal  string         `json:"user_defined_goal,omitempty"`
-	DetectorCategory string         `json:"detector_category,omitempty"`
-	Severity         string         `json:"severity,omitempty"`
-	Properties       map[string]any `json:"properties,omitempty"`
-	Active           bool           `json:"active,omitempty"`
-	CreatedAt        string         `json:"created_at,omitempty"`
+	UUID                string               `json:"uuid"`
+	PromptSetID         string               `json:"prompt_set_id,omitempty"`
+	Prompt              string               `json:"prompt,omitempty"`
+	Goal                string               `json:"goal,omitempty"`
+	UserDefinedGoal     bool                 `json:"user_defined_goal,omitempty"`
+	DetectorCategory    string               `json:"detector_category,omitempty"`
+	Severity            string               `json:"severity,omitempty"`
+	Properties          map[string]any       `json:"properties,omitempty"`
+	PropertyAssignments []PropertyAssignment `json:"property_assignments,omitempty"`
+	Active              bool                 `json:"active,omitempty"`
+	Status              string               `json:"status,omitempty"`
+	ExtraInfo           map[string]any       `json:"extra_info,omitempty"`
+	CreatedAt           string               `json:"created_at,omitempty"`
+	UpdatedAt           string               `json:"updated_at,omitempty"`
 }
 
 // CustomPromptList is the paginated list of prompts.
@@ -542,27 +780,106 @@ type PropertyValuesMultipleResponse struct {
 	Properties map[string][]string `json:"properties"`
 }
 
+// --- Target context types ---
+
+// TargetMetadata holds target metadata for probing/profiling.
+type TargetMetadata struct {
+	MultiTurn                 bool           `json:"multi_turn,omitempty"`
+	MultiTurnErrorMessage     string         `json:"multi_turn_error_message,omitempty"`
+	RateLimit                 *int           `json:"rate_limit,omitempty"`
+	RateLimitEnabled          bool           `json:"rate_limit_enabled,omitempty"`
+	RateLimitErrorCode        *int           `json:"rate_limit_error_code,omitempty"`
+	RateLimitErrorJSON        map[string]any `json:"rate_limit_error_json,omitempty"`
+	RateLimitErrorMessage     string         `json:"rate_limit_error_message,omitempty"`
+	ContentFilterEnabled      bool           `json:"content_filter_enabled,omitempty"`
+	ContentFilterErrorCode    *int           `json:"content_filter_error_code,omitempty"`
+	ContentFilterErrorJSON    map[string]any `json:"content_filter_error_json,omitempty"`
+	ContentFilterErrorMessage string         `json:"content_filter_error_message,omitempty"`
+	ProbeMessage              string         `json:"probe_message,omitempty"`
+	RequestTimeout            *int           `json:"request_timeout,omitempty"`
+}
+
+// TargetBackground holds target background context.
+type TargetBackground struct {
+	Industry    string   `json:"industry,omitempty"`
+	UseCase     string   `json:"use_case,omitempty"`
+	Competitors []string `json:"competitors,omitempty"`
+}
+
+// TargetAdditionalContext holds additional context for a target.
+type TargetAdditionalContext struct {
+	BaseModel          string   `json:"base_model,omitempty"`
+	CoreArchitecture   string   `json:"core_architecture,omitempty"`
+	SystemPrompt       string   `json:"system_prompt,omitempty"`
+	LanguagesSupported []string `json:"languages_supported,omitempty"`
+	BannedKeywords     []string `json:"banned_keywords,omitempty"`
+	ToolsAccessible    []string `json:"tools_accessible,omitempty"`
+}
+
+// PropertyAssignment is a property name-value pair for prompts.
+type PropertyAssignment struct {
+	PropertyName  string `json:"property_name"`
+	PropertyValue string `json:"property_value"`
+}
+
+// ErrorLog represents a single error log entry.
+type ErrorLog struct {
+	JobID        string `json:"job_id,omitempty"`
+	TargetID     string `json:"target_id,omitempty"`
+	ErrorSource  string `json:"error_source,omitempty"`
+	ErrorType    string `json:"error_type,omitempty"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	CreatedAt    string `json:"created_at,omitempty"`
+}
+
 // --- Dashboard / Statistics types ---
+
+// CountByName is a name+count pair for statistics.
+type CountByName struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// RiskLevel is a level+count pair for risk profiles.
+type RiskLevel struct {
+	Level string `json:"level"`
+	Count int    `json:"count"`
+}
 
 // ScanStatisticsResponse is the scan statistics response.
 type ScanStatisticsResponse struct {
-	Stats map[string]any `json:"stats,omitempty"`
+	TotalScans           int           `json:"total_scans"`
+	TargetsScanned       int           `json:"targets_scanned"`
+	TargetsScannedByType []CountByName `json:"targets_scanned_by_type,omitempty"`
+	ScanStatus           []CountByName `json:"scan_status,omitempty"`
+	RiskProfile          []RiskLevel   `json:"risk_profile,omitempty"`
+}
+
+// ScoreTrendSeries is one data series in a score trend.
+type ScoreTrendSeries struct {
+	Label string    `json:"label"`
+	Data  []float64 `json:"data"`
 }
 
 // ScoreTrendResponse is the score trend response.
 type ScoreTrendResponse struct {
-	TargetID string           `json:"target_id,omitempty"`
-	Series   []map[string]any `json:"series,omitempty"`
+	Labels []string           `json:"labels,omitempty"`
+	Series []ScoreTrendSeries `json:"series,omitempty"`
 }
 
 // QuotaSummary is the quota summary.
 type QuotaSummary struct {
-	Details map[string]any `json:"details,omitempty"`
+	StaticQuota  int `json:"static_quota"`
+	StaticUsed   int `json:"static_used"`
+	DynamicQuota int `json:"dynamic_quota"`
+	DynamicUsed  int `json:"dynamic_used"`
+	CustomQuota  int `json:"custom_quota"`
+	CustomUsed   int `json:"custom_used"`
 }
 
 // ErrorLogListResponse is the paginated list of error logs.
 type ErrorLogListResponse struct {
-	Items      []map[string]any  `json:"items"`
+	Items      []ErrorLog        `json:"items"`
 	Pagination RedTeamPagination `json:"pagination"`
 }
 

--- a/aisec/redteam/models_test.go
+++ b/aisec/redteam/models_test.go
@@ -1,0 +1,544 @@
+package redteam
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// --- Enum tests ---
+
+func TestAttackStatus_Values(t *testing.T) {
+	vals := []AttackStatus{
+		AttackStatusInit, AttackStatusAttack, AttackStatusDetection,
+		AttackStatusReport, AttackStatusCompleted, AttackStatusFailed,
+	}
+	expected := []string{"INIT", "ATTACK", "DETECTION", "REPORT", "COMPLETED", "FAILED"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("AttackStatus[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestAttackType_Values(t *testing.T) {
+	vals := []AttackType{AttackTypeNormal, AttackTypeCustom}
+	expected := []string{"NORMAL", "CUSTOM"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("AttackType[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestAuthType_Values(t *testing.T) {
+	vals := []AuthType{AuthTypeOAuth, AuthTypeAccessToken}
+	expected := []string{"OAUTH", "ACCESS_TOKEN"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("AuthType[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestBrandSubCategory_Values(t *testing.T) {
+	vals := []BrandSubCategory{
+		BrandSubCategoryCompetitorEndorsements,
+		BrandSubCategoryBrandTarnishing,
+		BrandSubCategoryDiscriminatingClaims,
+		BrandSubCategoryPoliticalEndorsements,
+	}
+	expected := []string{"COMPETITOR_ENDORSEMENTS", "BRAND_TARNISHING_SELF_CRITICISM", "DISCRIMINATING_CLAIMS", "POLITICAL_ENDORSEMENTS"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("BrandSubCategory[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestComplianceSubCategory_Values(t *testing.T) {
+	vals := []ComplianceSubCategory{
+		ComplianceSubCategoryOWASP, ComplianceSubCategoryMITREATLAS,
+		ComplianceSubCategoryNIST, ComplianceSubCategoryDASFV2,
+	}
+	expected := []string{"OWASP", "MITRE_ATLAS", "NIST", "DASF_V2"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("ComplianceSubCategory[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestSafetySubCategory_Values(t *testing.T) {
+	vals := []SafetySubCategory{
+		SafetySubCategoryBias, SafetySubCategoryCBRN, SafetySubCategoryCybercrime,
+		SafetySubCategoryDrugs, SafetySubCategoryHateToxicAbuse,
+		SafetySubCategoryNonViolentCrimes, SafetySubCategoryPolitical,
+		SafetySubCategorySelfHarm, SafetySubCategorySexual,
+		SafetySubCategoryViolentCrimesWeapons,
+	}
+	expected := []string{
+		"BIAS", "CBRN", "CYBERCRIME", "DRUGS", "HATE_TOXIC_ABUSE",
+		"NON_VIOLENT_CRIMES", "POLITICAL", "SELF_HARM", "SEXUAL", "VIOLENT_CRIMES_WEAPONS",
+	}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("SafetySubCategory[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestSecuritySubCategory_Values(t *testing.T) {
+	vals := []SecuritySubCategory{
+		SecuritySubCategoryAdversarialSuffix, SecuritySubCategoryEvasion,
+		SecuritySubCategoryIndirectPromptInjection, SecuritySubCategoryJailbreak,
+		SecuritySubCategoryMultiTurn, SecuritySubCategoryPromptInjection,
+		SecuritySubCategoryRemoteCodeExecution, SecuritySubCategorySystemPromptLeak,
+		SecuritySubCategoryToolLeak, SecuritySubCategoryMalwareGeneration,
+	}
+	expected := []string{
+		"ADVERSARIAL_SUFFIX", "EVASION", "INDIRECT_PROMPT_INJECTION", "JAILBREAK",
+		"MULTI_TURN", "PROMPT_INJECTION", "REMOTE_CODE_EXECUTION", "SYSTEM_PROMPT_LEAK",
+		"TOOL_LEAK", "MALWARE_GENERATION",
+	}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("SecuritySubCategory[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestErrorSource_Values(t *testing.T) {
+	vals := []ErrorSource{
+		ErrorSourceTarget, ErrorSourceJob, ErrorSourceSystem,
+		ErrorSourceValidation, ErrorSourceTargetProfiling,
+	}
+	expected := []string{"TARGET", "JOB", "SYSTEM", "VALIDATION", "TARGET_PROFILING"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("ErrorSource[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestErrorTypeEnum_Values(t *testing.T) {
+	vals := []ErrorTypeEnum{
+		ErrorTypeContentFilter, ErrorTypeRateLimit, ErrorTypeAuthentication,
+		ErrorTypeNetwork, ErrorTypeValidation, ErrorTypeNetworkChannel, ErrorTypeUnknown,
+	}
+	expected := []string{"CONTENT_FILTER", "RATE_LIMIT", "AUTHENTICATION", "NETWORK", "VALIDATION", "NETWORK_CHANNEL", "UNKNOWN"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("ErrorTypeEnum[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestProfilingStatus_Values(t *testing.T) {
+	vals := []ProfilingStatus{
+		ProfilingStatusInit, ProfilingStatusQueued, ProfilingStatusInProgress,
+		ProfilingStatusCompleted, ProfilingStatusFailed,
+	}
+	expected := []string{"INIT", "QUEUED", "IN_PROGRESS", "COMPLETED", "FAILED"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("ProfilingStatus[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestStreamType_Values(t *testing.T) {
+	vals := []StreamType{StreamTypeNormal, StreamTypeAdversarial}
+	expected := []string{"NORMAL", "ADVERSARIAL"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("StreamType[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestPolicyType_Values(t *testing.T) {
+	vals := []PolicyType{
+		PolicyTypePromptInjection, PolicyTypeToxicContent,
+		PolicyTypeCustomTopicGuardrails, PolicyTypeMaliciousCodeDetection,
+		PolicyTypeMaliciousURLDetection, PolicyTypeSensitiveDataProtection,
+	}
+	expected := []string{
+		"PROMPT_INJECTION", "TOXIC_CONTENT", "CUSTOM_TOPIC_GUARDRAILS",
+		"MALICIOUS_CODE_DETECTION", "MALICIOUS_URL_DETECTION", "SENSITIVE_DATA_PROTECTION",
+	}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("PolicyType[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestGuardrailAction_Values(t *testing.T) {
+	vals := []GuardrailAction{GuardrailActionAllow, GuardrailActionBlock}
+	expected := []string{"ALLOW", "BLOCK"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("GuardrailAction[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestDateRangeFilter_Values(t *testing.T) {
+	vals := []DateRangeFilter{
+		DateRangeFilterLast7Days, DateRangeFilterLast15Days,
+		DateRangeFilterLast30Days, DateRangeFilterAll,
+	}
+	expected := []string{"LAST_7_DAYS", "LAST_15_DAYS", "LAST_30_DAYS", "ALL"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("DateRangeFilter[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestCountedQuotaEnum_Values(t *testing.T) {
+	vals := []CountedQuotaEnum{CountedQuotaHeld, CountedQuotaCounted, CountedQuotaNotCounted}
+	expected := []string{"HELD", "COUNTED", "NOT_COUNTED"}
+	for i, v := range vals {
+		if string(v) != expected[i] {
+			t.Errorf("CountedQuotaEnum[%d] = %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+// --- Struct tests ---
+
+func TestCustomPromptResponse_UserDefinedGoalBool(t *testing.T) {
+	j := `{"uuid":"p1","user_defined_goal":true,"status":"ACTIVE","updated_at":"2025-01-01T00:00:00Z"}`
+	var p CustomPromptResponse
+	if err := json.Unmarshal([]byte(j), &p); err != nil {
+		t.Fatal(err)
+	}
+	if !p.UserDefinedGoal {
+		t.Error("UserDefinedGoal should be true")
+	}
+	if p.Status != "ACTIVE" {
+		t.Errorf("Status = %q", p.Status)
+	}
+	if p.UpdatedAt != "2025-01-01T00:00:00Z" {
+		t.Errorf("UpdatedAt = %q", p.UpdatedAt)
+	}
+}
+
+func TestCustomPromptSetResponse_ExtraFields(t *testing.T) {
+	j := `{
+		"uuid":"s1","name":"test","version":"1","property_names":["color","size"],
+		"created_by_user_id":"u1","updated_by_user_id":"u2"
+	}`
+	var s CustomPromptSetResponse
+	if err := json.Unmarshal([]byte(j), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.Version != "1" {
+		t.Errorf("Version = %q", s.Version)
+	}
+	if len(s.PropertyNames) != 2 {
+		t.Errorf("PropertyNames = %v", s.PropertyNames)
+	}
+	if s.CreatedByUserID != "u1" {
+		t.Errorf("CreatedByUserID = %q", s.CreatedByUserID)
+	}
+}
+
+func TestCustomPromptSetReference_FullFields(t *testing.T) {
+	j := `{
+		"uuid":"r1","name":"ref-set","version":"2","status":"ACTIVE",
+		"active":true,"tsg_id":"t1","created_at":"2025-01-01","updated_at":"2025-06-01"
+	}`
+	var r CustomPromptSetReference
+	if err := json.Unmarshal([]byte(j), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.Name != "ref-set" {
+		t.Errorf("Name = %q", r.Name)
+	}
+	if r.Version != "2" {
+		t.Errorf("Version = %q", r.Version)
+	}
+	if r.Status != "ACTIVE" {
+		t.Errorf("Status = %q", r.Status)
+	}
+	if !r.Active {
+		t.Error("Active should be true")
+	}
+	if r.TsgID != "t1" {
+		t.Errorf("TsgID = %q", r.TsgID)
+	}
+}
+
+func TestGoal_FullFields(t *testing.T) {
+	j := `{
+		"uuid":"g1","goal_type":"BASE","status":"COMPLETED",
+		"goal":"extract secrets","safe_response":"I cannot help",
+		"jailbroken_response":"here are the secrets",
+		"goal_metadata":{"key":"val"},"custom_goal":true,
+		"tsg_id":"t1","job_id":"j1","threat":true,"version":2
+	}`
+	var g Goal
+	if err := json.Unmarshal([]byte(j), &g); err != nil {
+		t.Fatal(err)
+	}
+	if g.UUID != "g1" {
+		t.Errorf("UUID = %q", g.UUID)
+	}
+	if g.Goal != "extract secrets" {
+		t.Errorf("Goal = %q", g.Goal)
+	}
+	if g.SafeResponse != "I cannot help" {
+		t.Errorf("SafeResponse = %q", g.SafeResponse)
+	}
+	if g.JailbrokenResponse != "here are the secrets" {
+		t.Errorf("JailbrokenResponse = %q", g.JailbrokenResponse)
+	}
+	if !g.CustomGoal {
+		t.Error("CustomGoal should be true")
+	}
+	if g.TsgID != "t1" {
+		t.Errorf("TsgID = %q", g.TsgID)
+	}
+	if g.JobID != "j1" {
+		t.Errorf("JobID = %q", g.JobID)
+	}
+	if g.Threat == nil || !*g.Threat {
+		t.Error("Threat should be true")
+	}
+	if g.Version == nil || *g.Version != 2 {
+		t.Errorf("Version = %v", g.Version)
+	}
+}
+
+func TestTargetMetadata_JSON(t *testing.T) {
+	j := `{
+		"multi_turn":true,"rate_limit":10,"rate_limit_enabled":true,
+		"content_filter_enabled":true,"probe_message":"hello","request_timeout":30
+	}`
+	var m TargetMetadata
+	if err := json.Unmarshal([]byte(j), &m); err != nil {
+		t.Fatal(err)
+	}
+	if !m.MultiTurn {
+		t.Error("MultiTurn should be true")
+	}
+	if m.RateLimit == nil || *m.RateLimit != 10 {
+		t.Errorf("RateLimit = %v", m.RateLimit)
+	}
+	if !m.RateLimitEnabled {
+		t.Error("RateLimitEnabled should be true")
+	}
+	if m.ProbeMessage != "hello" {
+		t.Errorf("ProbeMessage = %q", m.ProbeMessage)
+	}
+}
+
+func TestTargetBackground_JSON(t *testing.T) {
+	j := `{"industry":"finance","use_case":"chatbot","competitors":["a","b"]}`
+	var b TargetBackground
+	if err := json.Unmarshal([]byte(j), &b); err != nil {
+		t.Fatal(err)
+	}
+	if b.Industry != "finance" {
+		t.Errorf("Industry = %q", b.Industry)
+	}
+	if len(b.Competitors) != 2 {
+		t.Errorf("Competitors = %v", b.Competitors)
+	}
+}
+
+func TestTargetAdditionalContext_JSON(t *testing.T) {
+	j := `{
+		"base_model":"gpt-4","system_prompt":"you are helpful",
+		"languages_supported":["en","fr"],"banned_keywords":["hack"]
+	}`
+	var c TargetAdditionalContext
+	if err := json.Unmarshal([]byte(j), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.BaseModel != "gpt-4" {
+		t.Errorf("BaseModel = %q", c.BaseModel)
+	}
+	if c.SystemPrompt != "you are helpful" {
+		t.Errorf("SystemPrompt = %q", c.SystemPrompt)
+	}
+	if len(c.LanguagesSupported) != 2 {
+		t.Errorf("LanguagesSupported = %v", c.LanguagesSupported)
+	}
+}
+
+func TestPropertyAssignment_JSON(t *testing.T) {
+	j := `{"property_name":"color","property_value":"red"}`
+	var p PropertyAssignment
+	if err := json.Unmarshal([]byte(j), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.PropertyName != "color" {
+		t.Errorf("PropertyName = %q", p.PropertyName)
+	}
+	if p.PropertyValue != "red" {
+		t.Errorf("PropertyValue = %q", p.PropertyValue)
+	}
+}
+
+func TestErrorLog_JSON(t *testing.T) {
+	j := `{
+		"job_id":"j1","target_id":"t1","error_source":"TARGET",
+		"error_type":"RATE_LIMIT","error_message":"too fast","created_at":"2025-01-01"
+	}`
+	var e ErrorLog
+	if err := json.Unmarshal([]byte(j), &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.JobID != "j1" {
+		t.Errorf("JobID = %q", e.JobID)
+	}
+	if e.ErrorSource != "TARGET" {
+		t.Errorf("ErrorSource = %q", e.ErrorSource)
+	}
+	if e.ErrorType != "RATE_LIMIT" {
+		t.Errorf("ErrorType = %q", e.ErrorType)
+	}
+}
+
+func TestStaticJobReport_TypedFields(t *testing.T) {
+	j := `{
+		"asr":75.5,"score":82.3,"report_summary":"test summary",
+		"severity_report":{"low":5,"medium":3,"high":1,"critical":0}
+	}`
+	var r StaticJobReport
+	if err := json.Unmarshal([]byte(j), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.ASR == nil || *r.ASR != 75.5 {
+		t.Errorf("ASR = %v", r.ASR)
+	}
+	if r.Score == nil || *r.Score != 82.3 {
+		t.Errorf("Score = %v", r.Score)
+	}
+	if r.ReportSummary != "test summary" {
+		t.Errorf("ReportSummary = %q", r.ReportSummary)
+	}
+}
+
+func TestDynamicJobReport_TypedFields(t *testing.T) {
+	j := `{
+		"total_goals":10,"total_streams":5,"total_threats":3,
+		"goals_achieved":7,"score":65.0,"asr":30.0,"report_summary":"dynamic test"
+	}`
+	var r DynamicJobReport
+	if err := json.Unmarshal([]byte(j), &r); err != nil {
+		t.Fatal(err)
+	}
+	if r.TotalGoals != 10 {
+		t.Errorf("TotalGoals = %d", r.TotalGoals)
+	}
+	if r.TotalStreams != 5 {
+		t.Errorf("TotalStreams = %d", r.TotalStreams)
+	}
+	if r.Score != 65.0 {
+		t.Errorf("Score = %f", r.Score)
+	}
+}
+
+func TestAttackDetailResponse_TypedFields(t *testing.T) {
+	j := `{
+		"uuid":"a1","tsg_id":"t1","job_id":"j1","target_id":"tgt1",
+		"prompt":"test prompt","status":"COMPLETED","threat":true,
+		"attack_type":"NORMAL","multi_turn":false,"severity":"HIGH",
+		"category":"SECURITY","sub_category":"JAILBREAK",
+		"category_display_name":"Security","sub_category_display_name":"Jailbreak"
+	}`
+	var a AttackDetailResponse
+	if err := json.Unmarshal([]byte(j), &a); err != nil {
+		t.Fatal(err)
+	}
+	if a.UUID != "a1" {
+		t.Errorf("UUID = %q", a.UUID)
+	}
+	if a.TsgID != "t1" {
+		t.Errorf("TsgID = %q", a.TsgID)
+	}
+	if a.Prompt != "test prompt" {
+		t.Errorf("Prompt = %q", a.Prompt)
+	}
+	if a.Status != "COMPLETED" {
+		t.Errorf("Status = %q", a.Status)
+	}
+	if a.Threat == nil || !*a.Threat {
+		t.Error("Threat should be true")
+	}
+	if a.AttackType != "NORMAL" {
+		t.Errorf("AttackType = %q", a.AttackType)
+	}
+	if a.Category != "SECURITY" {
+		t.Errorf("Category = %q", a.Category)
+	}
+	if a.SubCategory != "JAILBREAK" {
+		t.Errorf("SubCategory = %q", a.SubCategory)
+	}
+	if a.CategoryDisplayName != "Security" {
+		t.Errorf("CategoryDisplayName = %q", a.CategoryDisplayName)
+	}
+}
+
+func TestScoreTrendResponse_TypedFields(t *testing.T) {
+	j := `{"labels":["2025-01","2025-02"],"series":[{"label":"STATIC","data":[70.5,80.2]}]}`
+	var r ScoreTrendResponse
+	if err := json.Unmarshal([]byte(j), &r); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Labels) != 2 {
+		t.Errorf("Labels = %v", r.Labels)
+	}
+	if len(r.Series) != 1 {
+		t.Errorf("Series len = %d", len(r.Series))
+	}
+	if r.Series[0].Label != "STATIC" {
+		t.Errorf("Series[0].Label = %q", r.Series[0].Label)
+	}
+	if len(r.Series[0].Data) != 2 {
+		t.Errorf("Series[0].Data = %v", r.Series[0].Data)
+	}
+}
+
+func TestQuotaSummary_TypedFields(t *testing.T) {
+	j := `{
+		"static_quota":100,"static_used":50,"dynamic_quota":200,"dynamic_used":30,
+		"custom_quota":50,"custom_used":10
+	}`
+	var q QuotaSummary
+	if err := json.Unmarshal([]byte(j), &q); err != nil {
+		t.Fatal(err)
+	}
+	if q.StaticQuota != 100 {
+		t.Errorf("StaticQuota = %d", q.StaticQuota)
+	}
+	if q.DynamicUsed != 30 {
+		t.Errorf("DynamicUsed = %d", q.DynamicUsed)
+	}
+}
+
+func TestScanStatisticsResponse_TypedFields(t *testing.T) {
+	j := `{
+		"total_scans":100,"targets_scanned":5,
+		"targets_scanned_by_type":[{"name":"APPLICATION","count":3}],
+		"scan_status":[{"name":"COMPLETED","count":80}],
+		"risk_profile":[{"level":"HIGH","count":10}]
+	}`
+	var s ScanStatisticsResponse
+	if err := json.Unmarshal([]byte(j), &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.TotalScans != 100 {
+		t.Errorf("TotalScans = %d", s.TotalScans)
+	}
+	if s.TargetsScanned != 5 {
+		t.Errorf("TargetsScanned = %d", s.TargetsScanned)
+	}
+	if len(s.TargetsScannedByType) != 1 {
+		t.Errorf("TargetsScannedByType = %v", s.TargetsScannedByType)
+	}
+}


### PR DESCRIPTION
## Summary
- Add 15 missing enum types with all spec-defined values (AttackStatus, AttackType, AuthType, BrandSubCategory, ComplianceSubCategory, SafetySubCategory, SecuritySubCategory, ErrorSource, ErrorTypeEnum, ProfilingStatus, StreamType, PolicyType, GuardrailAction, DateRangeFilter, CountedQuotaEnum)
- Replace `map[string]any` with typed structs across report/statistics types (StaticJobReport, DynamicJobReport, AttackDetailResponse, AttackMultiTurnDetailResponse, ScanStatisticsResponse, ScoreTrendResponse, QuotaSummary, ErrorLogListResponse)
- Add typed target context structs (TargetMetadata, TargetBackground, TargetAdditionalContext)
- Add PropertyAssignment, ErrorLog, CountByName, RiskLevel, ScoreTrendSeries, SeverityReport, CategoryReport structs
- Fix `CustomPromptResponse.UserDefinedGoal` type: `string` → `bool`
- Expand CustomPromptSetResponse, CustomPromptSetReference, Goal with all spec fields
- 30 new model tests, all existing tests updated

Closes #44

## Test plan
- [x] 30 new enum + struct tests pass
- [x] All existing tests updated for new field types (no regressions)
- [x] `make check` passes (fmt + vet + lint + test)