### PR TITLE
fix: remove omitempty from spec-required response fields

### DIFF
--- a/aisec/management/models.go
+++ b/aisec/management/models.go
@@ -451,9 +451,9 @@ type DeleteConflictResponse struct {
 
 // APIKeyDPInfo holds API key + deployment profile info within a customer app.
 type APIKeyDPInfo struct {
-	ApiKeyName string `json:"api_key_name,omitempty"`
-	DpName     string `json:"dp_name,omitempty"`
-	AuthCode   string `json:"auth_code,omitempty"`
+	ApiKeyName string `json:"api_key_name"`
+	DpName     string `json:"dp_name"`
+	AuthCode   string `json:"auth_code"`
 }
 
 // CustomerAppWithKeyInfo extends CustomerApp with associated API key/DP info.

--- a/aisec/management/models_test.go
+++ b/aisec/management/models_test.go
@@ -1,0 +1,25 @@
+package management
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAPIKeyDPInfo_RequiredFieldsSerialized verifies spec-required fields
+// appear in JSON output even at zero values.
+func TestAPIKeyDPInfo_RequiredFieldsSerialized(t *testing.T) {
+	resp := APIKeyDPInfo{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"api_key_name", "dp_name", "auth_code"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}

--- a/aisec/modelsecurity/models.go
+++ b/aisec/modelsecurity/models.go
@@ -292,17 +292,17 @@ type ScanCreateRequest struct {
 // ScanBaseResponse is the base scan response.
 type ScanBaseResponse struct {
 	UUID                     string       `json:"uuid"`
-	TsgID                    string       `json:"tsg_id,omitempty"`
-	CreatedAt                string       `json:"created_at,omitempty"`
-	UpdatedAt                string       `json:"updated_at,omitempty"`
-	ModelURI                 string       `json:"model_uri,omitempty"`
-	Owner                    string       `json:"owner,omitempty"`
-	ScanOrigin               ScanOrigin   `json:"scan_origin,omitempty"`
-	SecurityGroupUUID        string       `json:"security_group_uuid,omitempty"`
-	SecurityGroupName        string       `json:"security_group_name,omitempty"`
-	ModelVersionUUID         string       `json:"model_version_uuid,omitempty"`
-	EvalOutcome              EvalOutcome  `json:"eval_outcome,omitempty"`
-	SourceType               SourceType   `json:"source_type,omitempty"`
+	TsgID                    string       `json:"tsg_id"`
+	CreatedAt                string       `json:"created_at"`
+	UpdatedAt                string       `json:"updated_at"`
+	ModelURI                 string       `json:"model_uri"`
+	Owner                    string       `json:"owner"`
+	ScanOrigin               ScanOrigin   `json:"scan_origin"`
+	SecurityGroupUUID        string       `json:"security_group_uuid"`
+	SecurityGroupName        string       `json:"security_group_name"`
+	ModelVersionUUID         string       `json:"model_version_uuid"`
+	EvalOutcome              EvalOutcome  `json:"eval_outcome"`
+	SourceType               SourceType   `json:"source_type"`
 	CreatedBy                string       `json:"created_by,omitempty"`
 	EnabledRuleCountSnapshot *int         `json:"enabled_rule_count_snapshot,omitempty"`
 	ErrorCode                string       `json:"error_code,omitempty"`
@@ -327,16 +327,16 @@ type ScanList struct {
 // RuleEvaluationResponse represents a single rule evaluation.
 type RuleEvaluationResponse struct {
 	UUID              string               `json:"uuid"`
-	TsgID             string               `json:"tsg_id,omitempty"`
-	CreatedAt         string               `json:"created_at,omitempty"`
-	UpdatedAt         string               `json:"updated_at,omitempty"`
-	Result            RuleEvaluationResult `json:"result,omitempty"`
-	ViolationCount    int                  `json:"violation_count,omitempty"`
-	RuleInstanceUUID  string               `json:"rule_instance_uuid,omitempty"`
-	ScanUUID          string               `json:"scan_uuid,omitempty"`
-	RuleName          string               `json:"rule_name,omitempty"`
-	RuleDescription   string               `json:"rule_description,omitempty"`
-	RuleInstanceState RuleState            `json:"rule_instance_state,omitempty"`
+	TsgID             string               `json:"tsg_id"`
+	CreatedAt         string               `json:"created_at"`
+	UpdatedAt         string               `json:"updated_at"`
+	Result            RuleEvaluationResult `json:"result"`
+	ViolationCount    int                  `json:"violation_count"`
+	RuleInstanceUUID  string               `json:"rule_instance_uuid"`
+	ScanUUID          string               `json:"scan_uuid"`
+	RuleName          string               `json:"rule_name"`
+	RuleDescription   string               `json:"rule_description"`
+	RuleInstanceState RuleState            `json:"rule_instance_state"`
 }
 
 // RuleEvaluationList is the paginated list of rule evaluations.
@@ -350,14 +350,14 @@ type RuleEvaluationList struct {
 // FileResponse represents a file in a scan.
 type FileResponse struct {
 	UUID             string         `json:"uuid"`
-	TsgID            string         `json:"tsg_id,omitempty"`
-	CreatedAt        string         `json:"created_at,omitempty"`
-	UpdatedAt        string         `json:"updated_at,omitempty"`
-	Path             string         `json:"path,omitempty"`
-	ParentPath       string         `json:"parent_path,omitempty"`
-	Type             FileType       `json:"type,omitempty"`
-	Result           FileScanResult `json:"result,omitempty"`
-	ModelVersionUUID string         `json:"model_version_uuid,omitempty"`
+	TsgID            string         `json:"tsg_id"`
+	CreatedAt        string         `json:"created_at"`
+	UpdatedAt        string         `json:"updated_at"`
+	Path             string         `json:"path"`
+	ParentPath       string         `json:"parent_path"`
+	Type             FileType       `json:"type"`
+	Result           FileScanResult `json:"result"`
+	ModelVersionUUID string         `json:"model_version_uuid"`
 	BlobID           string         `json:"blob_id,omitempty"`
 	Formats          []string       `json:"formats,omitempty"`
 	ScanUUID         string         `json:"scan_uuid,omitempty"`
@@ -374,14 +374,14 @@ type FileList struct {
 // ViolationResponse represents a rule violation.
 type ViolationResponse struct {
 	UUID              string    `json:"uuid"`
-	TsgID             string    `json:"tsg_id,omitempty"`
-	CreatedAt         string    `json:"created_at,omitempty"`
-	UpdatedAt         string    `json:"updated_at,omitempty"`
-	Description       string    `json:"description,omitempty"`
-	RuleInstanceUUID  string    `json:"rule_instance_uuid,omitempty"`
-	RuleName          string    `json:"rule_name,omitempty"`
-	RuleDescription   string    `json:"rule_description,omitempty"`
-	RuleInstanceState RuleState `json:"rule_instance_state,omitempty"`
+	TsgID             string    `json:"tsg_id"`
+	CreatedAt         string    `json:"created_at"`
+	UpdatedAt         string    `json:"updated_at"`
+	Description       string    `json:"description"`
+	RuleInstanceUUID  string    `json:"rule_instance_uuid"`
+	RuleName          string    `json:"rule_name"`
+	RuleDescription   string    `json:"rule_description"`
+	RuleInstanceState RuleState `json:"rule_instance_state"`
 	File              string    `json:"file,omitempty"`
 	Hash              string    `json:"hash,omitempty"`
 	Module            string    `json:"module,omitempty"`
@@ -439,14 +439,14 @@ type ModelSecurityGroupUpdateRequest struct {
 // ModelSecurityGroupResponse is a security group.
 type ModelSecurityGroupResponse struct {
 	UUID        string                  `json:"uuid"`
-	TsgID       string                  `json:"tsg_id,omitempty"`
-	CreatedAt   string                  `json:"created_at,omitempty"`
-	UpdatedAt   string                  `json:"updated_at,omitempty"`
-	Name        string                  `json:"name,omitempty"`
-	Description string                  `json:"description,omitempty"`
-	SourceType  SourceType              `json:"source_type,omitempty"`
-	State       ModelSecurityGroupState `json:"state,omitempty"`
-	IsTombstone bool                    `json:"is_tombstone,omitempty"`
+	TsgID       string                  `json:"tsg_id"`
+	CreatedAt   string                  `json:"created_at"`
+	UpdatedAt   string                  `json:"updated_at"`
+	Name        string                  `json:"name"`
+	Description string                  `json:"description"`
+	SourceType  SourceType              `json:"source_type"`
+	State       ModelSecurityGroupState `json:"state"`
+	IsTombstone bool                    `json:"is_tombstone"`
 }
 
 // ListModelSecurityGroupsResponse is the paginated list of security groups.
@@ -467,14 +467,14 @@ type ModelSecurityRuleInstanceUpdateRequest struct {
 // ModelSecurityRuleInstanceResponse is a rule instance within a security group.
 type ModelSecurityRuleInstanceResponse struct {
 	UUID              string                     `json:"uuid"`
-	TsgID             string                     `json:"tsg_id,omitempty"`
-	CreatedAt         string                     `json:"created_at,omitempty"`
-	UpdatedAt         string                     `json:"updated_at,omitempty"`
-	SecurityGroupUUID string                     `json:"security_group_uuid,omitempty"`
-	SecurityRuleUUID  string                     `json:"security_rule_uuid,omitempty"`
-	State             RuleState                  `json:"state,omitempty"`
+	TsgID             string                     `json:"tsg_id"`
+	CreatedAt         string                     `json:"created_at"`
+	UpdatedAt         string                     `json:"updated_at"`
+	SecurityGroupUUID string                     `json:"security_group_uuid"`
+	SecurityRuleUUID  string                     `json:"security_rule_uuid"`
+	State             RuleState                  `json:"state"`
 	FieldValues       map[string]any             `json:"field_values,omitempty"`
-	Rule              *ModelSecurityRuleResponse `json:"rule,omitempty"`
+	Rule              *ModelSecurityRuleResponse `json:"rule"`
 }
 
 // ListModelSecurityRuleInstancesResponse is the paginated list of rule instances.
@@ -488,15 +488,15 @@ type ListModelSecurityRuleInstancesResponse struct {
 // ModelSecurityRuleResponse is a security rule (read-only).
 type ModelSecurityRuleResponse struct {
 	UUID              string              `json:"uuid"`
-	Name              string              `json:"name,omitempty"`
-	Description       string              `json:"description,omitempty"`
-	RuleType          RuleType            `json:"rule_type,omitempty"`
-	CompatibleSources []SourceType        `json:"compatible_sources,omitempty"`
-	DefaultState      RuleState           `json:"default_state,omitempty"`
-	Remediation       *RuleRemediation    `json:"remediation,omitempty"`
-	EditableFields    []RuleEditableField `json:"editable_fields,omitempty"`
-	ConstantValues    map[string]any      `json:"constant_values,omitempty"`
-	DefaultValues     map[string]any      `json:"default_values,omitempty"`
+	Name              string              `json:"name"`
+	Description       string              `json:"description"`
+	RuleType          RuleType            `json:"rule_type"`
+	CompatibleSources []SourceType        `json:"compatible_sources"`
+	DefaultState      RuleState           `json:"default_state"`
+	Remediation       *RuleRemediation    `json:"remediation"`
+	EditableFields    []RuleEditableField `json:"editable_fields"`
+	ConstantValues    map[string]any      `json:"constant_values"`
+	DefaultValues     map[string]any      `json:"default_values"`
 }
 
 // ListModelSecurityRulesResponse is the paginated list of security rules.
@@ -509,8 +509,8 @@ type ListModelSecurityRulesResponse struct {
 
 // PyPIAuthResponse is the PyPI authentication response.
 type PyPIAuthResponse struct {
-	URL       string `json:"url,omitempty"`
-	ExpiresAt string `json:"expires_at,omitempty"`
+	URL       string `json:"url"`
+	ExpiresAt string `json:"expires_at"`
 }
 
 // --- List Options ---

--- a/aisec/modelsecurity/models_test.go
+++ b/aisec/modelsecurity/models_test.go
@@ -1,0 +1,174 @@
+package modelsecurity
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestScanBaseResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ScanBaseResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "model_uri", "owner",
+		"scan_origin", "security_group_uuid", "security_group_name",
+		"model_version_uuid", "eval_outcome", "source_type",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestRuleEvaluationResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := RuleEvaluationResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "result", "violation_count",
+		"rule_instance_uuid", "scan_uuid", "rule_name", "rule_description",
+		"rule_instance_state",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestFileResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := FileResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "path", "parent_path",
+		"type", "result", "model_version_uuid",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestViolationResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ViolationResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "description",
+		"rule_instance_uuid", "rule_name", "rule_description",
+		"rule_instance_state",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestModelSecurityGroupResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ModelSecurityGroupResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "name", "description",
+		"source_type", "state", "is_tombstone",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestModelSecurityRuleInstanceResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ModelSecurityRuleInstanceResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"tsg_id", "created_at", "updated_at", "security_group_uuid",
+		"security_rule_uuid", "state", "rule",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestModelSecurityRuleResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ModelSecurityRuleResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	required := []string{
+		"name", "description", "rule_type", "compatible_sources",
+		"default_state", "remediation", "editable_fields",
+		"constant_values", "default_values",
+	}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestPyPIAuthResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := PyPIAuthResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"url", "expires_at"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -348,9 +348,9 @@ type JobAbortResponse struct {
 
 // CategoryModel represents a red team attack category.
 type CategoryModel struct {
-	ID            string         `json:"id,omitempty"`
+	ID            string         `json:"id"`
 	Name          string         `json:"name,omitempty"`
-	SubCategories []SubCategory  `json:"sub_categories,omitempty"`
+	SubCategories []SubCategory  `json:"sub_categories"`
 	Details       map[string]any `json:"details,omitempty"`
 }
 

--- a/aisec/redteam/models_test.go
+++ b/aisec/redteam/models_test.go
@@ -706,3 +706,20 @@ func TestPropertyValuesMultipleResponse_DataKey(t *testing.T) {
 		t.Errorf("Data = %v", r.Data)
 	}
 }
+
+func TestCategoryModel_RequiredFieldsSerialized(t *testing.T) {
+	resp := CategoryModel{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"id", "sub_categories"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}

--- a/aisec/scan/models.go
+++ b/aisec/scan/models.go
@@ -67,9 +67,9 @@ type ScanResponse struct {
 	ProfileName              string            `json:"profile_name,omitempty"`
 	Category                 string            `json:"category"`
 	Action                   string            `json:"action"`
-	Timeout                  bool              `json:"timeout,omitempty"`
-	Error                    bool              `json:"error,omitempty"`
-	Errors                   []ContentError    `json:"errors,omitempty"`
+	Timeout                  bool              `json:"timeout"`
+	Error                    bool              `json:"error"`
+	Errors                   []ContentError    `json:"errors"`
 	PromptDetected           *PromptDetected   `json:"prompt_detected,omitempty"`
 	ResponseDetected         *ResponseDetected `json:"response_detected,omitempty"`
 	PromptMaskedData         *MaskedData       `json:"prompt_masked_data,omitempty"`
@@ -205,8 +205,8 @@ type IODetected struct {
 
 // ScanSummary holds aggregated detection flags and threats.
 type ScanSummary struct {
-	Detections *ToolDetectionFlags `json:"detections,omitempty"`
-	Threats    []string            `json:"threats,omitempty"`
+	Detections *ToolDetectionFlags `json:"detections"`
+	Threats    []string            `json:"threats"`
 }
 
 // ToolDetected holds detection results for tool/agent interactions.
@@ -227,8 +227,8 @@ type AsyncScanObject struct {
 
 // AsyncScanResponse is the async scan API response.
 type AsyncScanResponse struct {
-	Received string `json:"received,omitempty"`
-	ScanID   string `json:"scan_id,omitempty"`
+	Received string `json:"received"`
+	ScanID   string `json:"scan_id"`
 	ReportID string `json:"report_id,omitempty"`
 	Source   string `json:"source,omitempty"`
 }
@@ -348,16 +348,16 @@ type PiReport struct {
 
 // DlpSnippetMeta holds metadata for a DLP snippet.
 type DlpSnippetMeta struct {
-	DataPattern     string `json:"data_pattern,omitempty"`
-	ConfidenceLevel string `json:"confidence_level,omitempty"`
+	DataPattern     string `json:"data_pattern"`
+	ConfidenceLevel string `json:"confidence_level"`
 	DataPatternType string `json:"data_pattern_type,omitempty"`
-	Occurrence      int64  `json:"occurrence,omitempty"`
+	Occurrence      int64  `json:"occurrence"`
 }
 
 // DlpSnippetObject holds DLP snippet data with metadata.
 type DlpSnippetObject struct {
-	Meta     *DlpSnippetMeta `json:"meta,omitempty"`
-	Snippets []string        `json:"snippets,omitempty"`
+	Meta     *DlpSnippetMeta `json:"meta"`
+	Snippets []string        `json:"snippets"`
 }
 
 // CgReport holds contextual grounding report details.

--- a/aisec/scan/models_test.go
+++ b/aisec/scan/models_test.go
@@ -1,0 +1,93 @@
+package scan
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestScanResponse_RequiredFieldsSerialized verifies spec-required fields
+// appear in JSON output even at zero values (no omitempty).
+func TestScanResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := ScanResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"timeout", "error", "errors"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestAsyncScanResponse_RequiredFieldsSerialized(t *testing.T) {
+	resp := AsyncScanResponse{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"received", "scan_id"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestScanSummary_RequiredFieldsSerialized(t *testing.T) {
+	resp := ScanSummary{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"detections", "threats"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestDlpSnippetMeta_RequiredFieldsSerialized(t *testing.T) {
+	resp := DlpSnippetMeta{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"data_pattern", "confidence_level", "occurrence"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}
+
+func TestDlpSnippetObject_RequiredFieldsSerialized(t *testing.T) {
+	resp := DlpSnippetObject{}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	m := make(map[string]any)
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"meta", "snippets"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("required field %q missing from JSON", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Removed `omitempty` from ~80 JSON struct tags across all 4 SDK packages where the OpenAPI spec marks the field as `required`
- Added serialization tests verifying required fields appear in JSON at zero values
- Covers: scan (12 fields), management (3 fields), modelsecurity (37 data + 26 mgmt fields), redteam (2 fields)

Closes #50

## Test plan
- [x] New `*_RequiredFieldsSerialized` tests pass across all 4 packages
- [x] `make check` passes (fmt + vet + lint + test)
- [ ] CI passes on Go 1.22, 1.23, 1.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)