### PR TITLE
fix: resolve integration test failures across management and redteam

### DIFF
--- a/aisec/internal/oauth.go
+++ b/aisec/internal/oauth.go
@@ -168,6 +168,11 @@ func (c *OAuthClient) TokenEndpoint() string {
 	return c.tokenEndpoint
 }
 
+// ClientID returns the configured OAuth client ID.
+func (c *OAuthClient) ClientID() string {
+	return c.clientID
+}
+
 type oauthTokenResponse struct {
 	AccessToken string `json:"access_token"`
 	ExpiresIn   int    `json:"expires_in"`

--- a/aisec/management/client.go
+++ b/aisec/management/client.go
@@ -104,7 +104,7 @@ func (c *ProfilesClient) List(ctx context.Context, opts ListOpts) (*SecurityProf
 
 func (c *ProfilesClient) Update(ctx context.Context, profileID string, req UpdateProfileRequest) (*SecurityProfile, error) {
 	resp, err := internal.DoMgmtRequest[SecurityProfile](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPut, Path: aisec.MgmtProfilePath + "/" + profileID, Body: req,
+		Method: http.MethodPut, Path: aisec.MgmtProfilePath + "/uuid/" + profileID, Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -123,13 +123,18 @@ func (c *ProfilesClient) Delete(ctx context.Context, profileID string) (*DeleteP
 }
 
 func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error) {
-	resp, err := internal.DoMgmtRequest[SecurityProfile](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.MgmtProfilePath, Params: map[string]string{"profile_name": name},
-	})
+	// No dedicated get-by-name endpoint in the API spec.
+	// List all profiles and filter client-side.
+	resp, err := c.List(ctx, ListOpts{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}
-	return &resp.Data, nil
+	for _, p := range resp.Items {
+		if p.ProfileName == name {
+			return &p, nil
+		}
+	}
+	return nil, aisec.NewAISecSDKError("profile not found: "+name, aisec.ClientSideError)
 }
 
 // ForceDelete force-deletes a profile: DELETE /v1/mgmt/profile/{profile_id}/force?updated_by=
@@ -173,7 +178,7 @@ func (c *TopicsClient) List(ctx context.Context, opts ListOpts) (*CustomTopicLis
 
 func (c *TopicsClient) Update(ctx context.Context, topicID string, req UpdateTopicRequest) (*CustomTopic, error) {
 	resp, err := internal.DoMgmtRequest[CustomTopic](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPut, Path: aisec.MgmtTopicPath + "/" + topicID, Body: req,
+		Method: http.MethodPut, Path: aisec.MgmtTopicPath + "/uuid/" + topicID, Body: req,
 	})
 	if err != nil {
 		return nil, err
@@ -182,26 +187,26 @@ func (c *TopicsClient) Update(ctx context.Context, topicID string, req UpdateTop
 }
 
 func (c *TopicsClient) Delete(ctx context.Context, topicID string) (*DeleteTopicResponse, error) {
-	resp, err := internal.DoMgmtRequest[DeleteTopicResponse](ctx, c.svcCfg, internal.MgmtRequestOptions{
+	resp, err := internal.DoMgmtRequest[string](ctx, c.svcCfg, internal.MgmtRequestOptions{
 		Method: http.MethodDelete, Path: aisec.MgmtTopicPath + "/" + topicID,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &resp.Data, nil
+	return &DeleteTopicResponse{Message: resp.Data}, nil
 }
 
-// ForceDelete force-deletes a topic: DELETE /v1/mgmt/topic/{topic_id}/force?updated_by=
+// ForceDelete force-deletes a topic: DELETE /v1/mgmt/topic/force/{topic_id}?updated_by=
 func (c *TopicsClient) ForceDelete(ctx context.Context, topicID string, updatedBy string) (*DeleteTopicResponse, error) {
-	resp, err := internal.DoMgmtRequest[DeleteTopicResponse](ctx, c.svcCfg, internal.MgmtRequestOptions{
+	resp, err := internal.DoMgmtRequest[string](ctx, c.svcCfg, internal.MgmtRequestOptions{
 		Method: http.MethodDelete,
-		Path:   aisec.MgmtTopicForcePath + "/" + topicID + "/force",
+		Path:   aisec.MgmtTopicForcePath + "/force/" + topicID,
 		Params: map[string]string{"updated_by": updatedBy},
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &resp.Data, nil
+	return &DeleteTopicResponse{Message: resp.Data}, nil
 }
 
 // ApiKeysClient provides API key lifecycle operations.
@@ -330,13 +335,18 @@ func (c *DlpProfilesClient) List(ctx context.Context, opts ListOpts) (*DlpProfil
 }
 
 func (c *DlpProfilesClient) Get(ctx context.Context, profileID string) (*DlpProfile, error) {
-	resp, err := internal.DoMgmtRequest[DlpProfile](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.MgmtDLPProfilesPath + "/" + profileID,
-	})
+	// No dedicated get-by-ID endpoint in the API spec.
+	// List all DLP profiles and filter client-side.
+	resp, err := c.List(ctx, ListOpts{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}
-	return &resp.Data, nil
+	for _, p := range resp.Items {
+		if p.ID == profileID {
+			return &p, nil
+		}
+	}
+	return nil, aisec.NewAISecSDKError("DLP profile not found: "+profileID, aisec.ClientSideError)
 }
 
 // DeploymentProfilesClient provides read-only access to deployment profiles.
@@ -398,9 +408,10 @@ type OAuthManagementClient struct {
 	svcCfg *internal.OAuthServiceConfig
 }
 
-func (c *OAuthManagementClient) GetToken(ctx context.Context) (*OAuthToken, error) {
+func (c *OAuthManagementClient) GetToken(ctx context.Context, req OAuthTokenRequest) (*OAuthToken, error) {
 	resp, err := internal.DoMgmtRequest[OAuthToken](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.MgmtOAuthTokenPath,
+		Method: http.MethodPost, Path: aisec.MgmtOAuthTokenPath,
+		Body: req,
 	})
 	if err != nil {
 		return nil, err

--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -433,7 +433,7 @@ func TestOAuth_GetToken(t *testing.T) {
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
-	token, err := client.OAuth.GetToken(context.Background())
+	token, err := client.OAuth.GetToken(context.Background(), OAuthTokenRequest{ClientID: "test-client", CustomerApp: "test-app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -488,10 +488,12 @@ func TestProfiles_GetByName(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("method = %s", r.Method)
 		}
-		if r.URL.Query().Get("profile_name") != "my-profile" {
-			t.Errorf("profile_name = %q", r.URL.Query().Get("profile_name"))
-		}
-		_ = json.NewEncoder(w).Encode(SecurityProfile{ProfileID: "p-1", ProfileName: "my-profile"})
+		_ = json.NewEncoder(w).Encode(SecurityProfileListResponse{
+			Items: []SecurityProfile{
+				{ProfileID: "p-1", ProfileName: "my-profile"},
+				{ProfileID: "p-2", ProfileName: "other"},
+			},
+		})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -553,7 +555,7 @@ func TestTopics_Delete(t *testing.T) {
 		if r.Method != "DELETE" {
 			t.Errorf("method = %s", r.Method)
 		}
-		_ = json.NewEncoder(w).Encode(DeleteTopicResponse{Message: "deleted"})
+		_ = json.NewEncoder(w).Encode("deleted")
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -573,13 +575,13 @@ func TestTopics_ForceDelete(t *testing.T) {
 		if r.Method != "DELETE" {
 			t.Errorf("method = %s", r.Method)
 		}
-		if !strings.Contains(r.URL.Path, "/topic/t-1/force") {
-			t.Errorf("path = %q, want /topic/t-1/force", r.URL.Path)
+		if !strings.Contains(r.URL.Path, "/topic/force/t-1") {
+			t.Errorf("path = %q, want /topic/force/t-1", r.URL.Path)
 		}
 		if r.URL.Query().Get("updated_by") != "admin@example.com" {
 			t.Errorf("updated_by = %q", r.URL.Query().Get("updated_by"))
 		}
-		_ = json.NewEncoder(w).Encode(DeleteTopicResponse{Message: "force deleted"})
+		_ = json.NewEncoder(w).Encode("force deleted")
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()
@@ -689,7 +691,12 @@ func TestDlpProfiles_Get(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("method = %s", r.Method)
 		}
-		_ = json.NewEncoder(w).Encode(DlpProfile{ID: "dlp-1", Name: "test-dlp"})
+		_ = json.NewEncoder(w).Encode(DlpProfileListResponse{
+			Items: []DlpProfile{
+				{ID: "dlp-1", Name: "test-dlp"},
+				{ID: "dlp-2", Name: "other"},
+			},
+		})
 	})
 	defer tokenSrv.Close()
 	defer apiSrv.Close()

--- a/aisec/management/integration_test.go
+++ b/aisec/management/integration_test.go
@@ -5,6 +5,7 @@ package management
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -116,8 +117,9 @@ func TestIntegration_Topics_CRUD(t *testing.T) {
 		t.Logf("Verified topic %s appears in list (%d total)", created.TopicID, len(listResp.Items))
 	}
 
-	// 3. Update topic description
+	// 3. Update topic description (topic_name is required by the API)
 	updated, err := client.Topics.Update(ctx, created.TopicID, UpdateTopicRequest{
+		TopicName:   topicName,
 		Description: "updated description for integration test",
 	})
 	if err != nil {
@@ -215,7 +217,27 @@ func TestIntegration_OAuth_GetToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	token, err := client.OAuth.GetToken(ctx)
+	// Requires a valid Apigee client_id for a customer app
+	clientID := os.Getenv("PANW_MGMT_OAUTH_APP_CLIENT_ID")
+	if clientID == "" {
+		t.Skip("PANW_MGMT_OAUTH_APP_CLIENT_ID not set")
+	}
+
+	// Look up an existing customer app to use
+	apps, err := client.CustomerApps.List(ctx, ListOpts{Limit: 1})
+	if err != nil {
+		t.Fatalf("CustomerApps.List: %v", err)
+	}
+	if len(apps.Items) == 0 {
+		t.Skip("no customer apps found, cannot test OAuth.GetToken")
+	}
+	appName := apps.Items[0].AppName
+	t.Logf("Using customer app: %s", appName)
+
+	token, err := client.OAuth.GetToken(ctx, OAuthTokenRequest{
+		ClientID:    clientID,
+		CustomerApp: appName,
+	})
 	if err != nil {
 		t.Fatalf("OAuth.GetToken failed: %v", err)
 	}

--- a/aisec/management/models.go
+++ b/aisec/management/models.go
@@ -433,6 +433,12 @@ type ScanLogListResponse struct {
 	Revision               int32                   `json:"revision,omitempty"`
 }
 
+// OAuthTokenRequest is the request body for getting an OAuth token via the management API.
+type OAuthTokenRequest struct {
+	ClientID    string `json:"client_id"`
+	CustomerApp string `json:"customer_app,omitempty"`
+}
+
 // OAuthToken represents an OAuth token from the management API.
 type OAuthToken struct {
 	AccessToken string `json:"access_token,omitempty"`

--- a/aisec/redteam/models.go
+++ b/aisec/redteam/models.go
@@ -813,7 +813,7 @@ type TargetMetadata struct {
 	ContentFilterErrorJSON    map[string]any `json:"content_filter_error_json,omitempty"`
 	ContentFilterErrorMessage string         `json:"content_filter_error_message,omitempty"`
 	ProbeMessage              string         `json:"probe_message,omitempty"`
-	RequestTimeout            *int           `json:"request_timeout,omitempty"`
+	RequestTimeout            *float64       `json:"request_timeout,omitempty"`
 }
 
 // TargetBackground holds target background context.


### PR DESCRIPTION
## Summary

- **Topics.Delete/ForceDelete**: API returns a JSON string (`"successfully deleted..."`), not a JSON object — changed to `DoMgmtRequest[string]` and wrap into `DeleteTopicResponse`
- **Topics.ForceDelete path**: fixed from `/topic/{id}/force` to `/topic/force/{id}` (matching TS SDK)
- **Topics.Update**: integration test now includes `topic_name` (required by API)
- **OAuth.GetToken**: changed signature from `GetToken(ctx, customerApp)` to `GetToken(ctx, OAuthTokenRequest)` so caller provides `client_id` (not hardcoded from management OAuth config)
- **Profiles.GetByName / DlpProfiles.Get**: refactored to list+filter (no individual GET-by-name/id endpoints exist)
- **Profiles.Update / Topics.Update**: fixed path to include `/uuid/` segment
- **redteam TargetMetadata.RequestTimeout**: `*int` → `*float64` (OpenAPI spec says `type: number`)
- **OAuthClient**: added `ClientID()` accessor for use in token request body

## Test plan

- [x] `make check` passes (unit tests, lint, vet, fmt)
- [x] All 23 integration tests pass across 4 packages (2 expected skips: ScanLogs timeout, OAuth missing env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)