### PR TITLE
docs: align all documentation with current codebase

### DIFF
--- a/aisec/doc.go
+++ b/aisec/doc.go
@@ -11,15 +11,20 @@
 //
 // Scan API with API key:
 //
-//	import "github.com/cdot65/prisma-airs-go/aisec"
+//	import (
+//	    "github.com/cdot65/prisma-airs-go/aisec"
+//	    "github.com/cdot65/prisma-airs-go/aisec/scan"
+//	)
 //
 //	cfg := aisec.NewConfig(aisec.WithAPIKey("your-api-key"))
-//	scanner := aisec.NewScanner(cfg)
+//	scanner := scan.NewScanner(cfg)
 //	resp, err := scanner.SyncScan(ctx, profile, content)
 //
 // Management API with OAuth2:
 //
-//	client := aisec.NewManagementClient(aisec.ManagementOpts{
+//	import "github.com/cdot65/prisma-airs-go/aisec/management"
+//
+//	client, err := management.NewClient(management.Opts{
 //	    ClientID:     "id",
 //	    ClientSecret: "secret",
 //	    TsgID:        "tsg-id",

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v0.1.1
+
+- **Red Team targets**: align all target models with OpenAPI spec (`TargetCreateRequest`, `TargetUpdateRequest`, `TargetContextUpdate`, `TargetProfileResponse`, `TargetListItem`)
+- **Management enums**: add `ProfileAction` (`allow`, `block`, `alert`, disabled) and `ToxicContentAction` (compound severity-threshold values) typed enums for all security profile action fields
+- **Release CI**: add Go module proxy publish step to release workflow
+- Remove `omitempty` from spec-required response fields across all packages
+
 ## v0.1.0 — Initial Release
 
 - Project scaffolding and Go module setup

--- a/docs/examples/api-key-rotation.md
+++ b/docs/examples/api-key-rotation.md
@@ -41,9 +41,10 @@ func main() {
     // 2. Identify expiring keys (within 7 days)
     threshold := time.Now().Add(7 * 24 * time.Hour)
     for _, key := range keys.Items {
-        if key.ExpiresAt.Before(threshold) {
+        expiry, _ := time.Parse(time.RFC3339, key.Expiration)
+        if !expiry.IsZero() && expiry.Before(threshold) {
             fmt.Printf("Key %s expires at %s — regenerating\n",
-                key.ApiKeyName, key.ExpiresAt.Format(time.RFC3339))
+                key.ApiKeyName, key.Expiration)
 
             // 3. Regenerate the key
             newKey, err := client.ApiKeys.Regenerate(ctx, key.ApiKeyID, management.RegenerateKeyRequest{

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -33,10 +33,10 @@ cfg := aisec.NewConfig(
 
 ```go
 // From environment variables
-client := management.NewClient(management.Opts{})
+client, err := management.NewClient(management.Opts{})
 
 // Explicit configuration
-client := management.NewClient(management.Opts{
+client, err := management.NewClient(management.Opts{
     ClientID:     "your-client-id",
     ClientSecret: "your-client-secret",
     TsgID:        "1234567890",
@@ -76,9 +76,9 @@ Falls back to `PANW_MGMT_*` variables if service-specific variables are not set.
 | Region | Endpoint |
 |--------|----------|
 | US (default) | `https://service.api.aisecurity.paloaltonetworks.com` |
-| EU | `https://service.api.aisecurity.eu.paloaltonetworks.com` |
-| India | `https://service.api.aisecurity.in.paloaltonetworks.com` |
-| Singapore | `https://service.api.aisecurity.sg.paloaltonetworks.com` |
+| EU | `https://service-de.api.aisecurity.paloaltonetworks.com` |
+| India | `https://service-in.api.aisecurity.paloaltonetworks.com` |
+| Singapore | `https://service-sg.api.aisecurity.paloaltonetworks.com` |
 
 ### Management / Model Security / Red Team
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -112,7 +112,7 @@ func main() {
     }
 
     for _, s := range scans.Items {
-        fmt.Printf("Scan: %s (Status: %s)\n", s.Name, s.EvalOutcome)
+        fmt.Printf("Scan: %s (Status: %s)\n", s.UUID, s.EvalOutcome)
     }
 }
 ```
@@ -142,7 +142,7 @@ func main() {
         log.Fatal(err)
     }
 
-    for _, t := range targets.Items {
+    for _, t := range targets.Data {
         fmt.Printf("Target: %s (%s)\n", t.Name, t.UUID)
     }
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -51,16 +51,14 @@ const (
 
 // Batch limits
 const (
-    MaxScanIDs         = 5
-    MaxReportIDs       = 5
-    MaxBatchScanObjects = 5
+    MaxNumberOfScanIDs          = 5
+    MaxNumberOfReportIDs        = 5
+    MaxNumberOfBatchScanObjects = 5
 )
 
 // Retry
-const (
-    MaxRetries             = 5
-    ForceRetryStatusCodes  = []int{500, 502, 503, 504}
-)
+const MaxNumberOfRetries = 5
+var HTTPForceRetryStatusCodes = []int{500, 502, 503, 504}
 ```
 
 ---
@@ -72,7 +70,7 @@ const (
 ```go
 func NewScanner(cfg *aisec.Config) *Scanner
 
-func (s *Scanner) SyncScan(ctx context.Context, profile AiProfile, content *Content, opts ...SyncScanOption) (*ScanResponse, error)
+func (s *Scanner) SyncScan(ctx context.Context, profile AiProfile, content *Content, opts ...SyncScanOpts) (*ScanResponse, error)
 func (s *Scanner) AsyncScan(ctx context.Context, objects []AsyncScanObject) (*AsyncScanResponse, error)
 func (s *Scanner) QueryByScanIDs(ctx context.Context, scanIDs []string) ([]ScanIDResult, error)
 func (s *Scanner) QueryByReportIDs(ctx context.Context, reportIDs []string) ([]ThreatScanReport, error)
@@ -103,12 +101,52 @@ type AiProfile struct {
 }
 
 type ScanResponse struct {
-    Category         string            `json:"category"`
-    Action           string            `json:"action"`
-    ScanID           string            `json:"scan_id"`
-    ReportID         string            `json:"report_id"`
-    PromptDetected   *PromptDetected   `json:"prompt_detected,omitempty"`
-    ResponseDetected *ResponseDetected `json:"response_detected,omitempty"`
+    Source                   string            `json:"source,omitempty"`
+    ReportID                 string            `json:"report_id"`
+    ScanID                   string            `json:"scan_id"`
+    TrID                     string            `json:"tr_id,omitempty"`
+    SessionID                string            `json:"session_id,omitempty"`
+    ProfileID                string            `json:"profile_id,omitempty"`
+    ProfileName              string            `json:"profile_name,omitempty"`
+    Category                 string            `json:"category"`
+    Action                   string            `json:"action"`
+    Timeout                  bool              `json:"timeout"`
+    Error                    bool              `json:"error"`
+    Errors                   []ContentError    `json:"errors"`
+    PromptDetected           *PromptDetected   `json:"prompt_detected,omitempty"`
+    ResponseDetected         *ResponseDetected `json:"response_detected,omitempty"`
+    PromptMaskedData         *MaskedData       `json:"prompt_masked_data,omitempty"`
+    ResponseMaskedData       *MaskedData       `json:"response_masked_data,omitempty"`
+    PromptDetectionDetails   *DetectionDetails `json:"prompt_detection_details,omitempty"`
+    ResponseDetectionDetails *DetectionDetails `json:"response_detection_details,omitempty"`
+    ToolDetected             *ToolDetected     `json:"tool_detected,omitempty"`
+    CreatedAt                string            `json:"created_at,omitempty"`
+    CompletedAt              string            `json:"completed_at,omitempty"`
+}
+
+type AsyncScanObject struct {
+    ReqID   uint32      `json:"req_id"`
+    ScanReq ScanRequest `json:"scan_req"`
+}
+
+type AsyncScanResponse struct {
+    Received string `json:"received"`
+    ScanID   string `json:"scan_id"`
+    ReportID string `json:"report_id,omitempty"`
+    Source   string `json:"source,omitempty"`
+}
+
+type ToolEvent struct {
+    Metadata *ToolEventMetadata `json:"metadata,omitempty"`
+    Input    string             `json:"input,omitempty"`
+    Output   string             `json:"output,omitempty"`
+}
+
+type ToolEventMetadata struct {
+    Ecosystem   string `json:"ecosystem"`
+    Method      string `json:"method"`
+    ServerName  string `json:"server_name"`
+    ToolInvoked string `json:"tool_invoked,omitempty"`
 }
 ```
 
@@ -119,7 +157,7 @@ type ScanResponse struct {
 ### Client
 
 ```go
-func NewClient(opts Opts) *Client
+func NewClient(opts Opts) (*Client, error)
 
 type Opts struct {
     ClientID      string
@@ -171,6 +209,50 @@ func (c *ApiKeysClient) Delete(ctx context.Context, keyName string, updatedBy st
 func (c *ApiKeysClient) Regenerate(ctx context.Context, keyID string, req RegenerateKeyRequest) (*ApiKey, error)
 ```
 
+### CustomerAppsClient
+
+```go
+func (c *CustomerAppsClient) Create(ctx context.Context, req CreateAppRequest) (*CustomerApp, error)
+func (c *CustomerAppsClient) List(ctx context.Context, opts ListOpts) (*CustomerAppListResponse, error)
+func (c *CustomerAppsClient) Get(ctx context.Context, appName string) (*CustomerApp, error)
+func (c *CustomerAppsClient) Update(ctx context.Context, appID string, req UpdateAppRequest) (*CustomerApp, error)
+func (c *CustomerAppsClient) Delete(ctx context.Context, appName string, updatedBy string) (*DeleteAppResponse, error)
+```
+
+### ScanLogsClient
+
+```go
+func (c *ScanLogsClient) List(ctx context.Context, opts ScanLogListOpts) (*ScanLogListResponse, error)
+```
+
+### OAuthManagementClient
+
+```go
+func (c *OAuthManagementClient) GetToken(ctx context.Context, req OAuthTokenRequest) (*OAuthToken, error)
+func (c *OAuthManagementClient) InvalidateToken(ctx context.Context) (*InvalidateTokenResponse, error)
+```
+
+### Action Enums
+
+```go
+type ProfileAction string
+
+const (
+    ProfileActionAllow    ProfileAction = "allow"
+    ProfileActionBlock    ProfileAction = "block"
+    ProfileActionAlert    ProfileAction = "alert"
+    ProfileActionDisabled ProfileAction = ""
+)
+
+type ToxicContentAction string
+
+const (
+    ToxicContentHighBlockModerateAllow ToxicContentAction = "high:block, moderate:allow"
+    ToxicContentHighBlockModerateBlock ToxicContentAction = "high:block, moderate:block"
+    ToxicContentHighAllowModerateAllow ToxicContentAction = "high:allow, moderate:allow"
+)
+```
+
 ---
 
 ## Package `modelsecurity`
@@ -178,7 +260,7 @@ func (c *ApiKeysClient) Regenerate(ctx context.Context, keyID string, req Regene
 ### Client
 
 ```go
-func NewClient(opts Opts) *Client
+func NewClient(opts Opts) (*Client, error)
 
 type Opts struct {
     ClientID      string
@@ -206,7 +288,7 @@ func (c *Client) GetPyPIAuth(ctx context.Context) (*PyPIAuthResponse, error)
 ### Client
 
 ```go
-func NewClient(opts Opts) *Client
+func NewClient(opts Opts) (*Client, error)
 
 type Opts struct {
     ClientID      string
@@ -219,18 +301,18 @@ type Opts struct {
 }
 
 type Client struct {
-    Scans              *ScansClient
-    Reports            *ReportsClient
+    Scans               *ScansClient
+    Reports             *ReportsClient
     CustomAttackReports *CustomAttackReportsClient
-    Targets            *TargetsClient
-    CustomAttacks      *CustomAttacksClient
+    Targets             *TargetsClient
+    CustomAttacks       *CustomAttacksClient
 }
 
 // Convenience methods
-func (c *Client) GetScanStatistics(ctx context.Context, params StatsParams) (*ScanStatisticsResponse, error)
+func (c *Client) GetScanStatistics(ctx context.Context, params map[string]string) (*ScanStatisticsResponse, error)
 func (c *Client) GetScoreTrend(ctx context.Context, targetID string) (*ScoreTrendResponse, error)
 func (c *Client) GetQuota(ctx context.Context) (*QuotaSummary, error)
-func (c *Client) GetErrorLogs(ctx context.Context, jobID string, opts ErrorLogOpts) (*ErrorLogListResponse, error)
+func (c *Client) GetErrorLogs(ctx context.Context, jobID string, opts ListOpts) (*ErrorLogListResponse, error)
 func (c *Client) UpdateSentiment(ctx context.Context, req SentimentRequest) (*SentimentResponse, error)
 func (c *Client) GetSentiment(ctx context.Context, jobID string) (*SentimentResponse, error)
 func (c *Client) GetDashboardOverview(ctx context.Context) (*DashboardOverviewResponse, error)
@@ -253,6 +335,7 @@ const (
 const (
     ActionAllow = "allow"
     ActionBlock = "block"
+    ActionAlert = "alert"
 )
 
 // Category
@@ -268,14 +351,17 @@ const (
 ### Detection Services
 
 ```go
+type DetectionServiceName string
+
 const (
-    DetectionServiceDLP   = "DLP"
-    DetectionServiceTC    = "TC"
-    DetectionServiceDBS   = "DBS"
-    DetectionServiceCI    = "CI"
-    DetectionServiceURLF  = "URLF"
-    DetectionServiceTG    = "TG"
-    DetectionServiceCG    = "CG"
-    DetectionServiceAGENT = "AGENT"
+    DetectionServiceDLP            DetectionServiceName = "dlp"
+    DetectionServiceInjection      DetectionServiceName = "injection"
+    DetectionServiceURLCats        DetectionServiceName = "url_cats"
+    DetectionServiceToxicContent   DetectionServiceName = "toxic_content"
+    DetectionServiceMaliciousCode  DetectionServiceName = "malicious_code"
+    DetectionServiceAgent          DetectionServiceName = "agent"
+    DetectionServiceTopicViolation DetectionServiceName = "topic_violation"
+    DetectionServiceDBSecurity     DetectionServiceName = "db_security"
+    DetectionServiceUngrounded     DetectionServiceName = "ungrounded"
 )
 ```

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -87,9 +87,9 @@ newKey, err := client.ApiKeys.Regenerate(ctx, "key-id", management.RegenerateKey
 ```go
 app, err := client.CustomerApps.Create(ctx, management.CreateAppRequest{...})
 apps, err := client.CustomerApps.List(ctx, management.ListOpts{})
-app, err := client.CustomerApps.Get(ctx, "app-id")
+app, err := client.CustomerApps.Get(ctx, "app-name")
 updated, err := client.CustomerApps.Update(ctx, "app-id", management.UpdateAppRequest{...})
-resp, err := client.CustomerApps.Delete(ctx, "app-id")
+resp, err := client.CustomerApps.Delete(ctx, "app-name", "admin@example.com")
 ```
 
 ### DlpProfiles — DLP Data Profiles (Read-Only)
@@ -110,15 +110,20 @@ profile, err := client.DeploymentProfiles.Get(ctx, "profile-id")
 
 ```go
 logs, err := client.ScanLogs.List(ctx, management.ScanLogListOpts{
-    Limit: 50,
+    TimeInterval: 24,
+    TimeUnit:     "hour",
+    PageNumber:   1,
+    PageSize:     50,
+    Filter:       "all",
 })
-logEntry, err := client.ScanLogs.Get(ctx, "log-id")
 ```
 
 ### OAuth — Token Management
 
 ```go
-token, err := client.OAuth.GetToken(ctx)
+token, err := client.OAuth.GetToken(ctx, management.OAuthTokenRequest{
+    ClientID: "your-client-id",
+})
 resp, err := client.OAuth.InvalidateToken(ctx)
 ```
 

--- a/docs/services/red-team-api.md
+++ b/docs/services/red-team-api.md
@@ -33,7 +33,7 @@ graph TD
 
 ```go
 // Create a scan job
-job, err := client.Scans.Create(ctx, redteam.CreateScanRequest{
+job, err := client.Scans.Create(ctx, redteam.JobCreateRequest{
     Name:     "security-audit",
     TargetID: "target-uuid",
     // ...
@@ -51,7 +51,7 @@ resp, err := client.Scans.Abort(ctx, "job-uuid")
 // Get attack categories
 categories, err := client.Scans.GetCategories(ctx)
 for _, cat := range categories {
-    fmt.Printf("Category: %s (%d subcategories)\n", cat.Name, len(cat.Subcategories))
+    fmt.Printf("Category: %s (%d subcategories)\n", cat.Name, len(cat.SubCategories))
 }
 ```
 
@@ -59,23 +59,48 @@ for _, cat := range categories {
 
 ```go
 // Get static report (pre-computed)
-staticReport, err := client.Reports.GetStatic(ctx, "report-id")
+staticReport, err := client.Reports.GetStaticReport(ctx, "job-id")
 
 // Get dynamic report (on-demand)
-dynamicReport, err := client.Reports.GetDynamic(ctx, "report-id")
+dynamicReport, err := client.Reports.GetDynamicReport(ctx, "job-id")
 
-// Get combined report
-report, err := client.Reports.Get(ctx, "report-id")
+// List attacks in a report
+attacks, err := client.Reports.ListAttacks(ctx, "job-id", redteam.AttackListOpts{})
 
-// List reports
-reports, err := client.Reports.List(ctx, redteam.ReportListOpts{})
+// Get attack detail
+detail, err := client.Reports.GetAttackDetail(ctx, "job-id", "attack-id")
+
+// Get remediation and runtime policy
+remediation, err := client.Reports.GetStaticRemediation(ctx, "job-id")
+policy, err := client.Reports.GetStaticRuntimePolicy(ctx, "job-id")
+
+// List goals and streams
+goals, err := client.Reports.ListGoals(ctx, "job-id", redteam.GoalListOpts{})
+streams, err := client.Reports.ListGoalStreams(ctx, "job-id", "goal-id", redteam.ListOpts{})
+
+// Download report as PDF or CSV
+data, err := client.Reports.DownloadReport(ctx, "job-id", redteam.FileFormatPDF)
 ```
 
 ## Custom Attack Reports (Data Plane)
 
 ```go
-reports, err := client.CustomAttackReports.List(ctx, redteam.CustomAttackReportListOpts{})
-report, err := client.CustomAttackReports.Get(ctx, "report-id")
+// Get custom attack report for a job
+report, err := client.CustomAttackReports.GetReport(ctx, "job-id")
+
+// Get prompt sets and prompts
+promptSets, err := client.CustomAttackReports.GetPromptSets(ctx, "job-id")
+prompts, err := client.CustomAttackReports.GetPromptsBySet(ctx, "job-id", "prompt-set-id",
+    redteam.PromptsBySetListOpts{})
+detail, err := client.CustomAttackReports.GetPromptDetail(ctx, "job-id", "prompt-id")
+
+// List custom attacks in a report
+attacks, err := client.CustomAttackReports.ListCustomAttacks(ctx, "job-id",
+    redteam.CustomAttacksReportListOpts{})
+
+// Get attack outputs and property stats
+outputs, err := client.CustomAttackReports.GetAttackOutputs(ctx, "job-id", "attack-id")
+stats, err := client.CustomAttackReports.GetPropertyStats(ctx, "job-id")
 ```
 
 ## Targets (Management Plane)
@@ -115,12 +140,48 @@ updated, err = client.Targets.UpdateProfile(ctx, "target-uuid", redteam.TargetCo
 
 ## Custom Attacks (Management Plane)
 
+Manages custom prompt sets and individual prompts for attack testing.
+
+### Prompt Sets
+
 ```go
-attack, err := client.CustomAttacks.Create(ctx, redteam.CreateCustomAttackRequest{...})
-attacks, err := client.CustomAttacks.List(ctx, redteam.CustomAttackListOpts{})
-attack, err := client.CustomAttacks.Get(ctx, "attack-id")
-updated, err := client.CustomAttacks.Update(ctx, "attack-id", redteam.UpdateCustomAttackRequest{...})
-resp, err := client.CustomAttacks.Delete(ctx, "attack-id")
+// Create a custom prompt set
+promptSet, err := client.CustomAttacks.CreatePromptSet(ctx, redteam.CustomPromptSetCreateRequest{...})
+
+// List, get, update, archive prompt sets
+sets, err := client.CustomAttacks.ListPromptSets(ctx, redteam.PromptSetListOpts{})
+set, err := client.CustomAttacks.GetPromptSet(ctx, "prompt-set-uuid")
+updated, err := client.CustomAttacks.UpdatePromptSet(ctx, "prompt-set-uuid",
+    redteam.CustomPromptSetUpdateRequest{...})
+archived, err := client.CustomAttacks.ArchivePromptSet(ctx, "prompt-set-uuid",
+    redteam.CustomPromptSetArchiveRequest{...})
+
+// List active prompt sets
+active, err := client.CustomAttacks.ListActivePromptSets(ctx)
+```
+
+### Prompts
+
+```go
+// Create a prompt within a prompt set
+prompt, err := client.CustomAttacks.CreatePrompt(ctx, redteam.CustomPromptCreateRequest{...})
+
+// List, get, update, delete prompts
+prompts, err := client.CustomAttacks.ListPrompts(ctx, "prompt-set-id", redteam.PromptListOpts{})
+prompt, err := client.CustomAttacks.GetPrompt(ctx, "prompt-set-id", "prompt-id")
+updated, err := client.CustomAttacks.UpdatePrompt(ctx, "prompt-set-id", "prompt-id",
+    redteam.CustomPromptUpdateRequest{...})
+resp, err := client.CustomAttacks.DeletePrompt(ctx, "prompt-set-id", "prompt-id")
+```
+
+### Properties
+
+```go
+// Manage property names and values for custom attacks
+names, err := client.CustomAttacks.GetPropertyNames(ctx)
+resp, err := client.CustomAttacks.CreatePropertyName(ctx, redteam.PropertyNameCreateRequest{...})
+values, err := client.CustomAttacks.GetPropertyValues(ctx, "property-name")
+resp, err := client.CustomAttacks.CreatePropertyValue(ctx, redteam.PropertyValueCreateRequest{...})
 ```
 
 ## Convenience Methods
@@ -129,7 +190,7 @@ These are available directly on the `RedTeamClient`:
 
 ```go
 // Scan statistics dashboard
-stats, err := client.GetScanStatistics(ctx, redteam.StatsParams{})
+stats, err := client.GetScanStatistics(ctx, map[string]string{"key": "value"})
 
 // Score trend for a target
 trend, err := client.GetScoreTrend(ctx, "target-uuid")
@@ -138,7 +199,7 @@ trend, err := client.GetScoreTrend(ctx, "target-uuid")
 quota, err := client.GetQuota(ctx)
 
 // Error logs for a job
-logs, err := client.GetErrorLogs(ctx, "job-uuid", redteam.ErrorLogOpts{})
+logs, err := client.GetErrorLogs(ctx, "job-uuid", redteam.ListOpts{})
 
 // Sentiment
 resp, err := client.UpdateSentiment(ctx, redteam.SentimentRequest{...})

--- a/docs/services/scan-api.md
+++ b/docs/services/scan-api.md
@@ -50,16 +50,19 @@ Submits up to 5 scan objects for asynchronous processing.
 ```go
 objects := []scan.AsyncScanObject{
     {
-        AiProfile: scan.AiProfile{ProfileName: "my-profile"},
-        Contents: []scan.ContentInner{{
-            Prompt:   "Tell me how to hack a server",
-            Response: "I cannot assist with that.",
-        }},
+        ReqID: 1,
+        ScanReq: scan.ScanRequest{
+            AiProfile: scan.AiProfile{ProfileName: "my-profile"},
+            Contents: []scan.ContentInner{{
+                Prompt:   "Tell me how to hack a server",
+                Response: "I cannot assist with that.",
+            }},
+        },
     },
 }
 
 resp, err := scanner.AsyncScan(ctx, objects)
-// resp.ScanIDs contains the IDs for polling
+// resp.ScanID contains the ID for polling
 ```
 
 ### Query by Scan IDs
@@ -110,10 +113,14 @@ fmt.Println(content.ByteLength()) // total byte length of all fields
 ```go
 content, err := scan.NewContent(scan.ContentOpts{
     ToolEvent: &scan.ToolEvent{
-        Source:    "function_call",
-        Method:    "get_weather",
-        Arguments: `{"city": "Paris"}`,
-        Response:  `{"temp": 22}`,
+        Metadata: &scan.ToolEventMetadata{
+            Ecosystem:   "mcp",
+            Method:      "get_weather",
+            ServerName:  "weather-server",
+            ToolInvoked: "get_weather",
+        },
+        Input:  `{"city": "Paris"}`,
+        Output: `{"temp": 22}`,
     },
 })
 if err != nil {


### PR DESCRIPTION
## Summary
Full documentation audit and fix — ~30 misalignments corrected across 9 files:

- **aisec/doc.go**: fix package-level examples (`aisec.NewScanner` → `scan.NewScanner`, `aisec.NewManagementClient` → `management.NewClient`)
- **configuration.md**: fix regional endpoints (EU/India/Singapore URLs), add error return to NewClient examples
- **quick-start.md**: fix `targets.Items` → `targets.Data`, `s.Name` → `s.UUID`
- **scan-api.md**: fix AsyncScanObject struct (ReqID+ScanReq not AiProfile+Contents), fix ToolEvent fields (Metadata/Input/Output not Source/Method/Arguments/Response)
- **management-api.md**: remove non-existent `ScanLogs.Get()`, fix `CustomerApps.Delete()` sig (needs updatedBy), fix `OAuth.GetToken()` sig (needs OAuthTokenRequest)
- **red-team-api.md**: complete rewrite — fix `CreateScanRequest` → `JobCreateRequest`, replace non-existent Reports.Get/List with actual methods, replace non-existent CustomAttacks CRUD with actual PromptSet/Prompt/Property methods, fix `StatsParams` → `map[string]string`, fix `ErrorLogOpts` → `ListOpts`
- **api-reference.md**: fix `SyncScanOption` → `SyncScanOpts`, add error returns to all 3 NewClient sigs, fix constant names (`MaxScanIDs` → `MaxNumberOfScanIDs` etc.), add full ScanResponse/AsyncScanObject/ToolEvent structs, add ProfileAction/ToxicContentAction enums, fix DetectionService values, add CustomerApps/ScanLogs/OAuth method sigs
- **api-key-rotation.md**: fix `ExpiresAt` → `Expiration` (string, not time.Time)
- **release-notes.md**: add v0.1.1 section covering recent changes

Closes #61

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `make fmt && make vet && make build` — all clean
- [x] `mkdocs build --strict` — docs build without warnings
- [x] Every type, method, field, and constant referenced in docs verified against source code