### PR TITLE
docs: fix remaining misalignments from re-audit

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -187,6 +187,7 @@ func (c *ProfilesClient) Create(ctx context.Context, req CreateProfileRequest) (
 func (c *ProfilesClient) List(ctx context.Context, opts ListOpts) (*SecurityProfileListResponse, error)
 func (c *ProfilesClient) Update(ctx context.Context, profileID string, req UpdateProfileRequest) (*SecurityProfile, error)
 func (c *ProfilesClient) Delete(ctx context.Context, profileID string) (*DeleteProfileResponse, error)
+func (c *ProfilesClient) ForceDelete(ctx context.Context, profileID string, updatedBy string) (*DeleteProfileResponse, error)
 func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error)
 ```
 
@@ -197,7 +198,7 @@ func (c *TopicsClient) Create(ctx context.Context, req CreateTopicRequest) (*Cus
 func (c *TopicsClient) List(ctx context.Context, opts ListOpts) (*CustomTopicListResponse, error)
 func (c *TopicsClient) Update(ctx context.Context, topicID string, req UpdateTopicRequest) (*CustomTopic, error)
 func (c *TopicsClient) Delete(ctx context.Context, topicID string) (*DeleteTopicResponse, error)
-func (c *TopicsClient) ForceDelete(ctx context.Context, topicID string) (*DeleteTopicResponse, error)
+func (c *TopicsClient) ForceDelete(ctx context.Context, topicID string, updatedBy string) (*DeleteTopicResponse, error)
 ```
 
 ### ApiKeysClient
@@ -329,6 +330,7 @@ func (c *Client) GetDashboardOverview(ctx context.Context) (*DashboardOverviewRe
 const (
     VerdictBenign    = "benign"
     VerdictMalicious = "malicious"
+    VerdictUnknown   = "unknown"
 )
 
 // Action
@@ -340,11 +342,9 @@ const (
 
 // Category
 const (
-    CategoryPromptInjection = "prompt_injection"
-    CategoryJailbreak       = "jailbreak"
-    CategorySQLInjection    = "sql_injection"
-    CategoryXSS             = "xss"
-    // ... (see source for complete list)
+    CategoryBenign    = "benign"
+    CategoryMalicious = "malicious"
+    CategoryUnknown   = "unknown"
 )
 ```
 

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -54,6 +54,9 @@ updated, err := client.Profiles.Update(ctx, "profile-id", management.UpdateProfi
 
 // Delete
 resp, err := client.Profiles.Delete(ctx, "profile-id")
+
+// Force delete (requires updatedBy)
+resp, err = client.Profiles.ForceDelete(ctx, "profile-id", "admin@example.com")
 ```
 
 ### Topics — Custom Detection Topics
@@ -70,7 +73,7 @@ topic, err := client.Topics.Create(ctx, management.CreateTopicRequest{
 topics, err := client.Topics.List(ctx, management.ListOpts{})
 updated, err := client.Topics.Update(ctx, "topic-id", management.UpdateTopicRequest{...})
 resp, err := client.Topics.Delete(ctx, "topic-id")
-resp, err := client.Topics.ForceDelete(ctx, "topic-id")
+resp, err = client.Topics.ForceDelete(ctx, "topic-id", "admin@example.com")
 ```
 
 ### ApiKeys — API Key Lifecycle

--- a/docs/services/red-team-api.md
+++ b/docs/services/red-team-api.md
@@ -34,8 +34,8 @@ graph TD
 ```go
 // Create a scan job
 job, err := client.Scans.Create(ctx, redteam.JobCreateRequest{
-    Name:     "security-audit",
-    TargetID: "target-uuid",
+    Name:   "security-audit",
+    Target: redteam.TargetJobRequest{UUID: "target-uuid"},
     // ...
 })
 
@@ -78,8 +78,8 @@ policy, err := client.Reports.GetStaticRuntimePolicy(ctx, "job-id")
 goals, err := client.Reports.ListGoals(ctx, "job-id", redteam.GoalListOpts{})
 streams, err := client.Reports.ListGoalStreams(ctx, "job-id", "goal-id", redteam.ListOpts{})
 
-// Download report as PDF or CSV
-data, err := client.Reports.DownloadReport(ctx, "job-id", redteam.FileFormatPDF)
+// Download report as CSV, JSON, or ALL
+data, err := client.Reports.DownloadReport(ctx, "job-id", redteam.FileFormatCSV)
 ```
 
 ## Custom Attack Reports (Data Plane)


### PR DESCRIPTION
## Summary
Follow-up to #62 — second audit pass caught 7 remaining misalignments:

- **red-team-api.md**: `TargetID: "target-uuid"` → `Target: redteam.TargetJobRequest{UUID: "target-uuid"}` (field is a struct, not string); `FileFormatPDF` → `FileFormatCSV` (PDF doesn't exist, only CSV/JSON/ALL)
- **management-api.md**: Add missing `Profiles.ForceDelete()` method; fix `Topics.ForceDelete()` signature (missing `updatedBy` parameter)
- **api-reference.md**: Add `ProfilesClient.ForceDelete` method; fix `TopicsClient.ForceDelete` signature; fix Category constants (`CategoryPromptInjection` etc. don't exist — only `CategoryBenign/Malicious/Unknown`); add missing `VerdictUnknown` constant

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `make fmt && make vet && make build` — clean
- [x] `mkdocs build --strict` — docs build clean
- [x] Every fix verified against actual source code via grep