### PR TITLE
feat(management): add GetByID, fix GetByName highest revision

### DIFF
--- a/aisec/management/client.go
+++ b/aisec/management/client.go
@@ -122,19 +122,42 @@ func (c *ProfilesClient) Delete(ctx context.Context, profileID string) (*DeleteP
 	return &resp.Data, nil
 }
 
-func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error) {
-	// No dedicated get-by-name endpoint in the API spec.
-	// List all profiles and filter client-side.
+// GetByID retrieves a single profile by UUID. No dedicated API endpoint exists,
+// so this lists all profiles and filters client-side.
+func (c *ProfilesClient) GetByID(ctx context.Context, profileID string) (*SecurityProfile, error) {
 	resp, err := c.List(ctx, ListOpts{Limit: 1000})
 	if err != nil {
 		return nil, err
 	}
 	for _, p := range resp.Items {
-		if p.ProfileName == name {
+		if p.ProfileID == profileID {
 			return &p, nil
 		}
 	}
-	return nil, aisec.NewAISecSDKError("profile not found: "+name, aisec.ClientSideError)
+	return nil, aisec.NewAISecSDKError("profile not found: "+profileID, aisec.ClientSideError)
+}
+
+// GetByName retrieves a profile by name. When multiple revisions exist for the
+// same name, the one with the highest revision is returned. No dedicated API
+// endpoint exists, so this lists all profiles and filters client-side.
+func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error) {
+	resp, err := c.List(ctx, ListOpts{Limit: 1000})
+	if err != nil {
+		return nil, err
+	}
+	var best *SecurityProfile
+	for _, p := range resp.Items {
+		if p.ProfileName == name {
+			if best == nil || p.Revision > best.Revision {
+				match := p
+				best = &match
+			}
+		}
+	}
+	if best == nil {
+		return nil, aisec.NewAISecSDKError("profile not found: "+name, aisec.ClientSideError)
+	}
+	return best, nil
 }
 
 // ForceDelete force-deletes a profile: DELETE /v1/mgmt/profile/{profile_id}/force?updated_by=

--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -508,6 +508,100 @@ func TestProfiles_GetByName(t *testing.T) {
 	}
 }
 
+func TestProfiles_GetByName_HighestRevision(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SecurityProfileListResponse{
+			Items: []SecurityProfile{
+				{ProfileID: "p-1", ProfileName: "my-profile", Revision: 1},
+				{ProfileID: "p-2", ProfileName: "my-profile", Revision: 3},
+				{ProfileID: "p-3", ProfileName: "my-profile", Revision: 2},
+			},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	p, err := client.Profiles.GetByName(context.Background(), "my-profile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProfileID != "p-2" {
+		t.Errorf("expected highest revision (p-2), got %q", p.ProfileID)
+	}
+	if p.Revision != 3 {
+		t.Errorf("expected revision 3, got %d", p.Revision)
+	}
+}
+
+func TestProfiles_GetByName_NotFound(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SecurityProfileListResponse{
+			Items: []SecurityProfile{
+				{ProfileID: "p-1", ProfileName: "other"},
+			},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	_, err := client.Profiles.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile")
+	}
+	if !strings.Contains(err.Error(), "profile not found") {
+		t.Errorf("error = %q, want 'profile not found'", err.Error())
+	}
+}
+
+func TestProfiles_GetByID(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SecurityProfileListResponse{
+			Items: []SecurityProfile{
+				{ProfileID: "p-1", ProfileName: "first"},
+				{ProfileID: "p-2", ProfileName: "target"},
+				{ProfileID: "p-3", ProfileName: "third"},
+			},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	p, err := client.Profiles.GetByID(context.Background(), "p-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProfileID != "p-2" {
+		t.Errorf("ProfileID = %q, want p-2", p.ProfileID)
+	}
+	if p.ProfileName != "target" {
+		t.Errorf("ProfileName = %q, want target", p.ProfileName)
+	}
+}
+
+func TestProfiles_GetByID_NotFound(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(SecurityProfileListResponse{
+			Items: []SecurityProfile{
+				{ProfileID: "p-1", ProfileName: "first"},
+			},
+		})
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	_, err := client.Profiles.GetByID(context.Background(), "nonexistent-id")
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile ID")
+	}
+	if !strings.Contains(err.Error(), "profile not found") {
+		t.Errorf("error = %q, want 'profile not found'", err.Error())
+	}
+}
+
 func TestTopics_List(t *testing.T) {
 	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -185,10 +185,11 @@ type Client struct {
 ```go
 func (c *ProfilesClient) Create(ctx context.Context, req CreateProfileRequest) (*SecurityProfile, error)
 func (c *ProfilesClient) List(ctx context.Context, opts ListOpts) (*SecurityProfileListResponse, error)
+func (c *ProfilesClient) GetByID(ctx context.Context, profileID string) (*SecurityProfile, error)
+func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error)
 func (c *ProfilesClient) Update(ctx context.Context, profileID string, req UpdateProfileRequest) (*SecurityProfile, error)
 func (c *ProfilesClient) Delete(ctx context.Context, profileID string) (*DeleteProfileResponse, error)
 func (c *ProfilesClient) ForceDelete(ctx context.Context, profileID string, updatedBy string) (*DeleteProfileResponse, error)
-func (c *ProfilesClient) GetByName(ctx context.Context, name string) (*SecurityProfile, error)
 ```
 
 ### TopicsClient

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -46,7 +46,10 @@ profile, err := client.Profiles.Create(ctx, management.CreateProfileRequest{
 // List with pagination
 profiles, err := client.Profiles.List(ctx, management.ListOpts{Limit: 10, Offset: 0})
 
-// Get by name
+// Get by ID (client-side filter over List)
+profile, err := client.Profiles.GetByID(ctx, "profile-uuid")
+
+// Get by name (returns highest revision; client-side filter over List)
 profile, err := client.Profiles.GetByName(ctx, "my-profile")
 
 // Update


### PR DESCRIPTION
## Summary

- Add `GetByID(ctx, profileID)` method to `ProfilesClient` — lists all profiles and filters by UUID client-side (no dedicated API endpoint exists)
- Fix `GetByName` to return the profile with the **highest revision** when multiple revisions share the same name (TypeScript SDK parity)

Closes #64

## Test plan

- [x] `TestProfiles_GetByID` — correct profile returned from list
- [x] `TestProfiles_GetByID_NotFound` — ClientSideError when ID absent
- [x] `TestProfiles_GetByName_HighestRevision` — 3 revisions, highest selected
- [x] `TestProfiles_GetByName_NotFound` — error when name absent
- [x] Existing `TestProfiles_GetByName` still passes
- [x] `make check` passes (fmt, vet, lint, test -race)