### PR TITLE
feat(examples): profile CRUD example + integration tests

### DIFF
--- a/aisec/management/integration_test.go
+++ b/aisec/management/integration_test.go
@@ -252,3 +252,189 @@ func TestIntegration_OAuth_GetToken(t *testing.T) {
 	t.Logf("OAuth token: type=%s expiresIn=%s tokenLen=%d",
 		token.TokenType, token.ExpiresIn, len(token.AccessToken))
 }
+
+func TestIntegration_Profiles_CRUD(t *testing.T) {
+	client := newIntegrationClient(t)
+	profileName := fmt.Sprintf("go-sdk-inttest-%d", time.Now().UnixNano())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// 1. Create
+	created, err := client.Profiles.Create(ctx, CreateProfileRequest{
+		ProfileName: profileName,
+		Policy: &ProfilePolicy{
+			AiSecurityProfiles: []AiSecurityProfileConfig{
+				{
+					ModelType: "default",
+					ModelConfiguration: &ModelConfiguration{
+						MaskDataInStorage: false,
+						Latency: &LatencyConfig{
+							InlineTimeoutAction: ProfileActionBlock,
+							MaxInlineLatency:    5,
+						},
+						ModelProtection: []ModelProtectionConfig{
+							{Name: "prompt-injection", Action: ProfileActionBlock},
+						},
+						AgentProtection: []AgentProtectionConfig{
+							{Name: "agent-security", Action: ProfileActionAlert},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t.Logf("Created: id=%s name=%s revision=%d", created.ProfileID, created.ProfileName, created.Revision)
+
+	if created.ProfileID == "" {
+		t.Fatal("expected non-empty ProfileID")
+	}
+	if created.ProfileName != profileName {
+		t.Errorf("ProfileName = %q, want %q", created.ProfileName, profileName)
+	}
+	if created.Revision != 1 {
+		t.Errorf("Revision = %d, want 1", created.Revision)
+	}
+
+	// Cleanup
+	t.Cleanup(func() {
+		delCtx, delCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer delCancel()
+		_, err := client.Profiles.ForceDelete(delCtx, created.ProfileID, "integration-test")
+		if err != nil {
+			t.Logf("WARNING: cleanup ForceDelete %s: %v", created.ProfileID, err)
+		} else {
+			t.Logf("Cleanup: force-deleted %s", created.ProfileID)
+		}
+	})
+
+	// 2. List — verify profile appears
+	listResp, err := client.Profiles.List(ctx, ListOpts{Limit: 1000})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, p := range listResp.Items {
+		if p.ProfileID == created.ProfileID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("created profile %s not in list (%d items)", created.ProfileID, len(listResp.Items))
+	}
+	t.Logf("List: %d profiles, created profile found=%v", len(listResp.Items), found)
+
+	// 3. GetByID
+	byID, err := client.Profiles.GetByID(ctx, created.ProfileID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if byID.ProfileID != created.ProfileID {
+		t.Errorf("GetByID ProfileID = %q, want %q", byID.ProfileID, created.ProfileID)
+	}
+	if byID.ProfileName != profileName {
+		t.Errorf("GetByID ProfileName = %q, want %q", byID.ProfileName, profileName)
+	}
+	t.Logf("GetByID: id=%s name=%s revision=%d", byID.ProfileID, byID.ProfileName, byID.Revision)
+
+	// 4. GetByName
+	byName, err := client.Profiles.GetByName(ctx, profileName)
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if byName.ProfileName != profileName {
+		t.Errorf("GetByName ProfileName = %q, want %q", byName.ProfileName, profileName)
+	}
+	t.Logf("GetByName: id=%s revision=%d", byName.ProfileID, byName.Revision)
+
+	// 5. Update — add contextual-grounding, increase latency
+	updated, err := client.Profiles.Update(ctx, created.ProfileID, UpdateProfileRequest{
+		ProfileName: profileName,
+		Policy: &ProfilePolicy{
+			AiSecurityProfiles: []AiSecurityProfileConfig{
+				{
+					ModelType: "default",
+					ModelConfiguration: &ModelConfiguration{
+						MaskDataInStorage: false,
+						Latency: &LatencyConfig{
+							InlineTimeoutAction: ProfileActionBlock,
+							MaxInlineLatency:    10,
+						},
+						ModelProtection: []ModelProtectionConfig{
+							{Name: "prompt-injection", Action: ProfileActionBlock},
+							{Name: "contextual-grounding", Action: ProfileActionBlock},
+						},
+						AgentProtection: []AgentProtectionConfig{
+							{Name: "agent-security", Action: ProfileActionBlock},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Revision != 2 {
+		t.Errorf("Updated Revision = %d, want 2", updated.Revision)
+	}
+	t.Logf("Updated: id=%s revision=%d", updated.ProfileID, updated.Revision)
+
+	// 6. GetByName after update — should return highest revision
+	latest, err := client.Profiles.GetByName(ctx, profileName)
+	if err != nil {
+		t.Fatalf("GetByName after update: %v", err)
+	}
+	if latest.Revision < 2 {
+		t.Errorf("GetByName revision = %d, want >= 2", latest.Revision)
+	}
+	t.Logf("GetByName after update: id=%s revision=%d", latest.ProfileID, latest.Revision)
+
+	// 7. Delete (cleanup runs via t.Cleanup)
+}
+
+func TestIntegration_Profiles_GetByID(t *testing.T) {
+	client := newIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// List to find an existing profile
+	resp, err := client.Profiles.List(ctx, ListOpts{Limit: 5})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(resp.Items) == 0 {
+		t.Skip("no profiles found")
+	}
+
+	target := resp.Items[0]
+	t.Logf("Target: id=%s name=%s", target.ProfileID, target.ProfileName)
+
+	profile, err := client.Profiles.GetByID(ctx, target.ProfileID)
+	if err != nil {
+		t.Fatalf("GetByID(%s): %v", target.ProfileID, err)
+	}
+	if profile.ProfileID != target.ProfileID {
+		t.Errorf("ProfileID = %q, want %q", profile.ProfileID, target.ProfileID)
+	}
+	if profile.ProfileName != target.ProfileName {
+		t.Errorf("ProfileName = %q, want %q", profile.ProfileName, target.ProfileName)
+	}
+	t.Logf("GetByID: id=%s name=%s revision=%d", profile.ProfileID, profile.ProfileName, profile.Revision)
+}
+
+func TestIntegration_Profiles_GetByID_NotFound(t *testing.T) {
+	client := newIntegrationClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := client.Profiles.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Fatal("expected error for nonexistent profile ID")
+	}
+	t.Logf("Expected error: %v", err)
+}

--- a/examples/profile-crud/main.go
+++ b/examples/profile-crud/main.go
@@ -1,0 +1,178 @@
+// Example: full CRUD lifecycle for security profiles using the management API.
+//
+// Requires environment variables:
+//
+//	PANW_MGMT_CLIENT_ID, PANW_MGMT_CLIENT_SECRET, PANW_MGMT_TSG_ID
+//
+// Usage:
+//
+//	source .env  # or export the vars manually
+//	go run ./examples/profile-crud/
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/cdot65/prisma-airs-go/aisec/management"
+)
+
+func main() {
+	// ── 1. Initialize client ──────────────────────────────────────────────
+	fmt.Println("═══ Security Profile CRUD Example ═══")
+	fmt.Println()
+	fmt.Println("── Step 1: Initialize management client")
+
+	client, err := management.NewClient(management.Opts{
+		ClientID:     os.Getenv("PANW_MGMT_CLIENT_ID"),
+		ClientSecret: os.Getenv("PANW_MGMT_CLIENT_SECRET"),
+		TsgID:        os.Getenv("PANW_MGMT_TSG_ID"),
+	})
+	if err != nil {
+		log.Fatalf("NewClient: %v", err)
+	}
+	fmt.Println("   Client initialized successfully")
+	fmt.Println()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	profileName := fmt.Sprintf("sdk-example-%d", time.Now().UnixNano())
+
+	// ── 2. Create ─────────────────────────────────────────────────────────
+	fmt.Println("── Step 2: Create profile")
+	created, err := client.Profiles.Create(ctx, management.CreateProfileRequest{
+		ProfileName: profileName,
+		Policy: &management.ProfilePolicy{
+			AiSecurityProfiles: []management.AiSecurityProfileConfig{
+				{
+					ModelType: "default",
+					ModelConfiguration: &management.ModelConfiguration{
+						MaskDataInStorage: false,
+						Latency: &management.LatencyConfig{
+							InlineTimeoutAction: management.ProfileActionBlock,
+							MaxInlineLatency:    5,
+						},
+						ModelProtection: []management.ModelProtectionConfig{
+							{
+								Name:   "prompt-injection",
+								Action: management.ProfileActionBlock,
+							},
+						},
+						AgentProtection: []management.AgentProtectionConfig{
+							{
+								Name:   "agent-security",
+								Action: management.ProfileActionAlert,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Profiles.Create: %v", err)
+	}
+	printJSON("   Created", created)
+	fmt.Println()
+
+	// Ensure cleanup
+	defer func() {
+		fmt.Println("── Step 7: Cleanup (force delete)")
+		delCtx, delCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer delCancel()
+		resp, err := client.Profiles.ForceDelete(delCtx, created.ProfileID, "sdk-example")
+		if err != nil {
+			fmt.Printf("   ForceDelete: %v\n", err)
+		} else {
+			fmt.Printf("   ForceDelete: %s\n", resp.Message)
+		}
+	}()
+
+	// ── 3. List ───────────────────────────────────────────────────────────
+	fmt.Println("── Step 3: List profiles")
+	listResp, err := client.Profiles.List(ctx, management.ListOpts{Limit: 100})
+	if err != nil {
+		log.Fatalf("Profiles.List: %v", err)
+	}
+	fmt.Printf("   Total profiles: %d\n", len(listResp.Items))
+	for i, p := range listResp.Items {
+		fmt.Printf("   [%d] id=%s name=%s revision=%d active=%v\n",
+			i, p.ProfileID, p.ProfileName, p.Revision, p.Active)
+	}
+	fmt.Println()
+
+	// ── 4. GetByID ────────────────────────────────────────────────────────
+	fmt.Println("── Step 4: Get by ID")
+	byID, err := client.Profiles.GetByID(ctx, created.ProfileID)
+	if err != nil {
+		log.Fatalf("Profiles.GetByID: %v", err)
+	}
+	printJSON("   GetByID", byID)
+	fmt.Println()
+
+	// ── 5. GetByName ──────────────────────────────────────────────────────
+	fmt.Println("── Step 5: Get by Name")
+	byName, err := client.Profiles.GetByName(ctx, profileName)
+	if err != nil {
+		log.Fatalf("Profiles.GetByName: %v", err)
+	}
+	printJSON("   GetByName", byName)
+	fmt.Println()
+
+	// ── 6. Update ─────────────────────────────────────────────────────────
+	fmt.Println("── Step 6: Update profile")
+	updated, err := client.Profiles.Update(ctx, created.ProfileID, management.UpdateProfileRequest{
+		ProfileName: profileName,
+		Policy: &management.ProfilePolicy{
+			AiSecurityProfiles: []management.AiSecurityProfileConfig{
+				{
+					ModelType: "default",
+					ModelConfiguration: &management.ModelConfiguration{
+						MaskDataInStorage: false,
+						Latency: &management.LatencyConfig{
+							InlineTimeoutAction: management.ProfileActionBlock,
+							MaxInlineLatency:    10,
+						},
+						ModelProtection: []management.ModelProtectionConfig{
+							{
+								Name:   "prompt-injection",
+								Action: management.ProfileActionBlock,
+							},
+							{
+								Name:   "contextual-grounding",
+								Action: management.ProfileActionBlock,
+							},
+							{
+								Name:   "toxic-content",
+								Action: management.ProfileAction(management.ToxicContentHighBlockModerateAllow),
+							},
+						},
+						AgentProtection: []management.AgentProtectionConfig{
+							{
+								Name:   "agent-security",
+								Action: management.ProfileActionBlock,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("Profiles.Update: %v", err)
+	}
+	printJSON("   Updated", updated)
+	fmt.Println()
+
+	// Step 7 (delete) runs in the deferred cleanup above.
+}
+
+func printJSON(label string, v any) {
+	b, _ := json.MarshalIndent(v, "   ", "  ")
+	fmt.Printf("%s: %s\n", label, string(b))
+}


### PR DESCRIPTION
## Summary

- Add `examples/profile-crud/main.go` — full CRUD lifecycle (Create → List → GetByID → GetByName → Update → ForceDelete) using real API-valid values
- Add 3 integration tests: `TestIntegration_Profiles_CRUD`, `TestIntegration_Profiles_GetByID`, `TestIntegration_Profiles_GetByID_NotFound`
- All use correct protection names from live API (`prompt-injection`, `contextual-grounding`, `toxic-content`, `agent-security`)

Closes #66

## Test plan

- [x] `make check` passes (fmt, vet, lint, test -race)
- [x] `TestIntegration_Profiles_CRUD` — full lifecycle against live API
- [x] `TestIntegration_Profiles_GetByID` — retrieves existing profile by UUID
- [x] `TestIntegration_Profiles_GetByID_NotFound` — returns error for nonexistent UUID
- [x] `TestIntegration_Profiles_ReadOnly` — existing test still passes
- [x] Example builds and runs: `go run ./examples/profile-crud/`