### PR TITLE
docs: align all docs with codebase, add profile-crud example

### DIFF
--- a/aisec/management/integration_test.go
+++ b/aisec/management/integration_test.go
@@ -277,7 +277,7 @@ func TestIntegration_Profiles_CRUD(t *testing.T) {
 							{Name: "prompt-injection", Action: ProfileActionBlock},
 						},
 						AgentProtection: []AgentProtectionConfig{
-							{Name: "agent-security", Action: ProfileActionAlert},
+							{Name: "agent-security", Action: ProfileActionBlock},
 						},
 					},
 				},

--- a/docs/examples/profile-crud.md
+++ b/docs/examples/profile-crud.md
@@ -1,0 +1,248 @@
+# Security Profile CRUD
+
+End-to-end example demonstrating all security profile operations: Create, List, GetByID, GetByName, Update, and ForceDelete.
+
+Source: [`examples/profile-crud/main.go`](https://github.com/cdot65/prisma-airs-go/blob/main/examples/profile-crud/main.go)
+
+## Prerequisites
+
+```bash
+export PANW_MGMT_CLIENT_ID=your-client-id
+export PANW_MGMT_CLIENT_SECRET=your-client-secret
+export PANW_MGMT_TSG_ID=your-tsg-id
+```
+
+Or use `set -a && source .env && set +a` to load from a `.env` file.
+
+## Build & Run
+
+```bash
+go build ./examples/profile-crud/
+go run ./examples/profile-crud/
+```
+
+## Workflow
+
+### Step 1: Initialize Client
+
+```go
+client, err := management.NewClient(management.Opts{
+    ClientID:     os.Getenv("PANW_MGMT_CLIENT_ID"),
+    ClientSecret: os.Getenv("PANW_MGMT_CLIENT_SECRET"),
+    TsgID:        os.Getenv("PANW_MGMT_TSG_ID"),
+})
+```
+
+### Step 2: Create Profile
+
+Creates a profile with prompt-injection blocking and agent security.
+
+```go
+created, err := client.Profiles.Create(ctx, management.CreateProfileRequest{
+    ProfileName: profileName,
+    Policy: &management.ProfilePolicy{
+        AiSecurityProfiles: []management.AiSecurityProfileConfig{
+            {
+                ModelType: "default",
+                ModelConfiguration: &management.ModelConfiguration{
+                    MaskDataInStorage: false,
+                    Latency: &management.LatencyConfig{
+                        InlineTimeoutAction: management.ProfileActionBlock,
+                        MaxInlineLatency:    5,
+                    },
+                    ModelProtection: []management.ModelProtectionConfig{
+                        {Name: "prompt-injection", Action: management.ProfileActionBlock},
+                    },
+                    AgentProtection: []management.AgentProtectionConfig{
+                        {Name: "agent-security", Action: management.ProfileActionBlock},
+                    },
+                },
+            },
+        },
+    },
+})
+```
+
+**Response:**
+
+```json
+{
+  "profile_id": "de02ba1f-2330-42e8-af28-1f06d95afe69",
+  "profile_name": "sdk-example-1774183739921371000",
+  "revision": 1,
+  "active": true,
+  "policy": {
+    "ai-security-profiles": [
+      {
+        "model-type": "default",
+        "model-configuration": {
+          "latency": {
+            "inline-timeout-action": "block",
+            "max-inline-latency": 5
+          },
+          "model-protection": [
+            {"name": "prompt-injection", "action": "block"}
+          ],
+          "agent-protection": [
+            {"name": "agent-security", "action": "block"}
+          ]
+        }
+      }
+    ]
+  },
+  "created_by": "test@test.com",
+  "updated_by": "test@test.com",
+  "last_modified_ts": "2026-03-22T12:49:00Z"
+}
+```
+
+### Step 3: List Profiles
+
+```go
+listResp, err := client.Profiles.List(ctx, management.ListOpts{Limit: 100})
+```
+
+**Response (abbreviated):**
+
+```
+Total profiles: 30
+[0] id=de02ba1f-... name=sdk-example-1774183739921371000 revision=1 active=true
+[1] id=6794c21b-... name=AI-Firewall-High-Security-Profile revision=4 active=true
+[2] id=aeda326a-... name=Truffles Agent revision=2 active=true
+...
+```
+
+### Step 4: Get by ID
+
+Retrieves a single profile by UUID. No dedicated API endpoint exists — lists all profiles and filters client-side.
+
+```go
+byID, err := client.Profiles.GetByID(ctx, created.ProfileID)
+```
+
+**Response:** Same structure as Create response.
+
+### Step 5: Get by Name
+
+Retrieves a profile by name. When multiple revisions exist, returns the one with the highest revision number.
+
+```go
+byName, err := client.Profiles.GetByName(ctx, profileName)
+```
+
+**Response:** Same structure as Create response. After an Update creates revision 2, `GetByName` returns the revision-2 profile.
+
+### Step 6: Update Profile
+
+Adds `contextual-grounding` and `toxic-content` protections, increases latency timeout to 10 seconds, upgrades agent-security to block.
+
+```go
+updated, err := client.Profiles.Update(ctx, created.ProfileID, management.UpdateProfileRequest{
+    ProfileName: profileName,
+    Policy: &management.ProfilePolicy{
+        AiSecurityProfiles: []management.AiSecurityProfileConfig{
+            {
+                ModelType: "default",
+                ModelConfiguration: &management.ModelConfiguration{
+                    MaskDataInStorage: false,
+                    Latency: &management.LatencyConfig{
+                        InlineTimeoutAction: management.ProfileActionBlock,
+                        MaxInlineLatency:    10,
+                    },
+                    ModelProtection: []management.ModelProtectionConfig{
+                        {Name: "prompt-injection", Action: management.ProfileActionBlock},
+                        {Name: "contextual-grounding", Action: management.ProfileActionBlock},
+                        {
+                            Name:   "toxic-content",
+                            Action: management.ProfileAction(management.ToxicContentHighBlockModerateAllow),
+                        },
+                    },
+                    AgentProtection: []management.AgentProtectionConfig{
+                        {Name: "agent-security", Action: management.ProfileActionBlock},
+                    },
+                },
+            },
+        },
+    },
+})
+```
+
+**Response:**
+
+```json
+{
+  "profile_id": "a5468b56-6512-4e61-b5cd-0f0dea0a56bf",
+  "profile_name": "sdk-example-1774183739921371000",
+  "revision": 2,
+  "active": true,
+  "policy": {
+    "ai-security-profiles": [
+      {
+        "model-type": "default",
+        "model-configuration": {
+          "latency": {
+            "inline-timeout-action": "block",
+            "max-inline-latency": 10
+          },
+          "model-protection": [
+            {"name": "prompt-injection", "action": "block"},
+            {"name": "contextual-grounding", "action": "block"},
+            {"name": "toxic-content", "action": "high:block, moderate:allow"}
+          ],
+          "agent-protection": [
+            {"name": "agent-security", "action": "block"}
+          ]
+        }
+      }
+    ]
+  },
+  "created_by": "test@test.com",
+  "updated_by": "none",
+  "last_modified_ts": "2026-03-22T12:49:02Z"
+}
+```
+
+!!! note "Update creates a new revision"
+    The `profile_id` changes after update (`de02ba1f...` to `a5468b56...`) and `revision` bumps from 1 to 2. Use `GetByName` to always get the latest revision.
+
+### Step 7: Force Delete
+
+```go
+resp, err := client.Profiles.ForceDelete(ctx, created.ProfileID, "sdk-example")
+```
+
+## Valid Protection Names
+
+Based on the live API, these are the valid names for each protection type:
+
+### model-protection
+
+| Name | Valid Actions |
+|------|-------------|
+| `prompt-injection` | `block`, `allow` |
+| `contextual-grounding` | `block`, `allow` |
+| `toxic-content` | `high:block, moderate:block`, `high:block, moderate:allow`, `high:allow, moderate:allow` |
+| `topic-guardrails` | `block`, `allow` (with `topic-list` array) |
+
+### agent-protection
+
+| Name | Valid Actions |
+|------|-------------|
+| `agent-security` | `block` |
+
+### latency
+
+| Field | Valid Values |
+|-------|-------------|
+| `inline-timeout-action` | `block`, `allow` |
+| `max-inline-latency` | integer (seconds) |
+
+### data-protection
+
+| Name | Valid Actions |
+|------|-------------|
+| `data-leak-detection` | `block`, `""` (disabled) |
+| `database-security-create` | `block`, `allow` |
+| `database-security-read` | `block`, `allow` |
+| `database-security-update` | `block`, `allow` |
+| `database-security-delete` | `block`, `allow` |

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -14,6 +14,7 @@ func NewConfig(opts ...ConfigOption) *Config
 func WithAPIKey(key string) ConfigOption
 func WithAPIToken(token string) ConfigOption
 func WithEndpoint(endpoint string) ConfigOption
+func WithNumRetries(n int) ConfigOption
 ```
 
 ### Error Types

--- a/docs/services/red-team-api.md
+++ b/docs/services/red-team-api.md
@@ -70,13 +70,19 @@ attacks, err := client.Reports.ListAttacks(ctx, "job-id", redteam.AttackListOpts
 // Get attack detail
 detail, err := client.Reports.GetAttackDetail(ctx, "job-id", "attack-id")
 
-// Get remediation and runtime policy
+// Get remediation and runtime policy (static and dynamic)
 remediation, err := client.Reports.GetStaticRemediation(ctx, "job-id")
 policy, err := client.Reports.GetStaticRuntimePolicy(ctx, "job-id")
+dynRemediation, err := client.Reports.GetDynamicRemediation(ctx, "job-id")
+dynPolicy, err := client.Reports.GetDynamicRuntimePolicy(ctx, "job-id")
+
+// Get multi-turn attack detail
+multiTurn, err := client.Reports.GetMultiTurnAttackDetail(ctx, "job-id", "attack-id")
 
 // List goals and streams
 goals, err := client.Reports.ListGoals(ctx, "job-id", redteam.GoalListOpts{})
 streams, err := client.Reports.ListGoalStreams(ctx, "job-id", "goal-id", redteam.ListOpts{})
+streamDetail, err := client.Reports.GetStreamDetail(ctx, "stream-id")
 
 // Download report as CSV, JSON, or ALL
 data, err := client.Reports.DownloadReport(ctx, "job-id", redteam.FileFormatCSV)
@@ -158,6 +164,10 @@ archived, err := client.CustomAttacks.ArchivePromptSet(ctx, "prompt-set-uuid",
 
 // List active prompt sets
 active, err := client.CustomAttacks.ListActivePromptSets(ctx)
+
+// Get prompt set reference and version info
+ref, err := client.CustomAttacks.GetPromptSetReference(ctx, "prompt-set-uuid")
+versionInfo, err := client.CustomAttacks.GetPromptSetVersionInfo(ctx, "prompt-set-uuid")
 ```
 
 ### Prompts
@@ -181,6 +191,7 @@ resp, err := client.CustomAttacks.DeletePrompt(ctx, "prompt-set-id", "prompt-id"
 names, err := client.CustomAttacks.GetPropertyNames(ctx)
 resp, err := client.CustomAttacks.CreatePropertyName(ctx, redteam.PropertyNameCreateRequest{...})
 values, err := client.CustomAttacks.GetPropertyValues(ctx, "property-name")
+multiValues, err := client.CustomAttacks.GetPropertyValuesMultiple(ctx, []string{"name1", "name2"})
 resp, err := client.CustomAttacks.CreatePropertyValue(ctx, redteam.PropertyValueCreateRequest{...})
 ```
 

--- a/examples/profile-crud/main.go
+++ b/examples/profile-crud/main.go
@@ -66,7 +66,7 @@ func main() {
 						AgentProtection: []management.AgentProtectionConfig{
 							{
 								Name:   "agent-security",
-								Action: management.ProfileActionAlert,
+								Action: management.ProfileActionBlock,
 							},
 						},
 					},

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Model Security API: services/model-security-api.md
       - Red Team API: services/red-team-api.md
   - Examples:
+      - Security Profile CRUD: examples/profile-crud.md
       - API Key Rotation: examples/api-key-rotation.md
   - Reference:
       - API Reference: reference/api-reference.md


### PR DESCRIPTION
## Summary
- Fix `ProfileActionAlert` → `ProfileActionBlock` for agent-security in example and integration test (matches real API behavior from `examples/output.json`)
- Add `docs/examples/profile-crud.md` — full end-to-end CRUD walkthrough with real API JSON responses and valid protection names reference
- Add 7 missing redteam methods to `docs/services/red-team-api.md`
- Add `WithNumRetries` to `docs/reference/api-reference.md`
- Update `mkdocs.yml` nav with examples section

Closes #68

## Test plan
- [x] `make check` passes
- [x] Integration tests pass with `ProfileActionBlock` for agent-security
- [x] Example runs against live API with correct action values
- [ ] CI passes
- [ ] Docs site builds cleanly