### PR TITLE
fix: tolerate non-JSON responses from ForceDelete endpoints

### DIFF
--- a/aisec/internal/mgmthttpclient.go
+++ b/aisec/internal/mgmthttpclient.go
@@ -92,6 +92,11 @@ func DoMgmtRequest[T any](ctx context.Context, svcCfg *OAuthServiceConfig, opts 
 	var data T
 	if len(respBody) > 0 {
 		if err := json.Unmarshal(respBody, &data); err != nil {
+			// Some endpoints (e.g. ForceDelete) return non-JSON on success.
+			// Tolerate parse failures for 2xx responses; return zero-value T.
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return &Response[T]{Status: resp.StatusCode, Data: data}, nil
+			}
 			return nil, aisec.WrapError("failed to parse response JSON", aisec.AISecSDKInternalError, err)
 		}
 	}

--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -158,6 +158,43 @@ func TestProfiles_ForceDelete(t *testing.T) {
 	}
 }
 
+func TestProfiles_ForceDelete_NonJSON(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		// Simulate the real API: returns plain text, not JSON
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("deleted"))
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.Profiles.ForceDelete(context.Background(), "p-1", "admin@example.com")
+	if err != nil {
+		t.Fatalf("expected no error for non-JSON 2xx response, got: %v", err)
+	}
+	// Zero-value message is acceptable when API returns non-JSON
+	_ = resp
+}
+
+func TestTopics_ForceDelete_NonJSON(t *testing.T) {
+	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Simulate the real API: returns empty body
+		w.WriteHeader(200)
+	})
+	defer tokenSrv.Close()
+	defer apiSrv.Close()
+
+	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
+	resp, err := client.Topics.ForceDelete(context.Background(), "t-1", "admin@example.com")
+	if err != nil {
+		t.Fatalf("expected no error for empty 2xx response, got: %v", err)
+	}
+	_ = resp
+}
+
 func TestTopics_CRUD(t *testing.T) {
 	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(CustomTopic{TopicID: "t-1", TopicName: "test"})


### PR DESCRIPTION
## Summary
- `DoMgmtRequest` now returns zero-value T on JSON parse failure for 2xx responses instead of erroring
- Fixes `Profiles.ForceDelete` and `Topics.ForceDelete` which fail with `AISEC_SDK_ERROR:failed to parse response JSON` because the live API returns plain text despite the OpenAPI spec declaring `application/json`
- Added unit tests for non-JSON 2xx response scenarios

Closes #70

## Test plan
- [x] `make check` passes
- [x] Unit tests: `TestProfiles_ForceDelete_NonJSON` and `TestTopics_ForceDelete_NonJSON`
- [x] Existing JSON-response ForceDelete tests still pass
- [ ] CI passes