### PR TITLE
docs: document ForceDelete non-JSON response behavior

### DIFF
--- a/docs/examples/profile-crud.md
+++ b/docs/examples/profile-crud.md
@@ -209,7 +209,15 @@ updated, err := client.Profiles.Update(ctx, created.ProfileID, management.Update
 
 ```go
 resp, err := client.Profiles.ForceDelete(ctx, created.ProfileID, "sdk-example")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println("Deleted successfully")
 ```
+
+!!! note "ForceDelete response"
+    The API returns a non-JSON response for successful deletes. The SDK handles this
+    gracefully — `err` will be `nil` on success, but `resp.Message` may be empty.
 
 ## Valid Protection Names
 

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -58,7 +58,7 @@ updated, err := client.Profiles.Update(ctx, "profile-id", management.UpdateProfi
 // Delete
 resp, err := client.Profiles.Delete(ctx, "profile-id")
 
-// Force delete (requires updatedBy)
+// Force delete (requires updatedBy; resp.Message may be empty)
 resp, err = client.Profiles.ForceDelete(ctx, "profile-id", "admin@example.com")
 ```
 
@@ -76,7 +76,7 @@ topic, err := client.Topics.Create(ctx, management.CreateTopicRequest{
 topics, err := client.Topics.List(ctx, management.ListOpts{})
 updated, err := client.Topics.Update(ctx, "topic-id", management.UpdateTopicRequest{...})
 resp, err := client.Topics.Delete(ctx, "topic-id")
-resp, err = client.Topics.ForceDelete(ctx, "topic-id", "admin@example.com")
+resp, err = client.Topics.ForceDelete(ctx, "topic-id", "admin@example.com") // resp.Message may be empty
 ```
 
 ### ApiKeys — API Key Lifecycle


### PR DESCRIPTION
## Summary
- Add note to `docs/examples/profile-crud.md` explaining ForceDelete returns non-JSON and `resp.Message` may be empty
- Add inline comments in `docs/services/management-api.md` for both Profiles and Topics ForceDelete

Follow-up to #71.

## Test plan
- [x] `make check` passes
- [ ] CI passes
- [ ] Docs site builds cleanly