### PR TITLE
chore: bump version to v0.2.1, add release notes

### DIFF
--- a/TERRAFORM_PROVIDER_NOTES.md
+++ b/TERRAFORM_PROVIDER_NOTES.md
@@ -1,0 +1,84 @@
+# Terraform Provider — Go SDK Changes (v0.2.0 → v0.2.1)
+
+Notes for the `terraform-provider-prisma-airs` on recent Go SDK changes that affect provider implementation.
+
+## Breaking / Behavioral Changes
+
+### ForceDelete now succeeds on non-JSON responses (v0.2.1)
+
+`DoMgmtRequest` tolerates non-JSON 2xx responses by returning a zero-value response struct instead of erroring. This means:
+
+- `Profiles.ForceDelete()` and `Topics.ForceDelete()` now return `nil` error on success
+- `resp.Message` may be empty string (API returns plain text, not `{"message": "..."}`)
+- Provider delete functions should check `err == nil` as the success indicator, not `resp.Message`
+
+```go
+// Before (broke with AISEC_SDK_ERROR:failed to parse response JSON)
+resp, err := client.Profiles.ForceDelete(ctx, id, updatedBy)
+
+// After (works — err is nil on success, resp.Message may be empty)
+_, err := client.Profiles.ForceDelete(ctx, id, updatedBy)
+if err != nil {
+    return diag.FromErr(err)
+}
+```
+
+## New Methods Available (v0.2.0)
+
+### Profiles.GetByID
+
+Client-side filter over `List()`. No dedicated API endpoint exists.
+
+```go
+profile, err := client.Profiles.GetByID(ctx, "profile-uuid")
+```
+
+- Returns `*SecurityProfile` or error if not found
+- Lists up to 1000 profiles and filters by `ProfileID`
+- Useful for Terraform `Read` functions
+
+### Profiles.GetByName (fixed)
+
+Now returns the highest revision when multiple revisions share the same name.
+
+```go
+profile, err := client.Profiles.GetByName(ctx, "my-profile")
+```
+
+- Previous behavior: returned first match (arbitrary revision)
+- New behavior: returns match with highest `Revision` number
+
+### Typed Action Enums
+
+```go
+// ProfileAction for model-protection, agent-protection, latency, data-protection
+management.ProfileActionAllow    // "allow"
+management.ProfileActionBlock    // "block"
+management.ProfileActionAlert    // "alert"
+management.ProfileActionDisabled // "" (disabled)
+
+// ToxicContentAction for toxic-content model-protection (compound values)
+management.ToxicContentHighBlockModerateAllow // "high:block, moderate:allow"
+management.ToxicContentHighBlockModerateBlock // "high:block, moderate:block"
+management.ToxicContentHighAllowModerateAllow // "high:allow, moderate:allow"
+```
+
+## Valid Protection Names (from live API)
+
+Use these when building Terraform schema validation:
+
+| Protection Type | Name | Valid Actions |
+|----------------|------|--------------|
+| model-protection | `prompt-injection` | `block`, `allow` |
+| model-protection | `contextual-grounding` | `block`, `allow` |
+| model-protection | `toxic-content` | compound ToxicContentAction values |
+| model-protection | `topic-guardrails` | `block`, `allow` (requires `topic-list`) |
+| agent-protection | `agent-security` | `block` only |
+| data-protection | `data-leak-detection` | `block`, `""` |
+| data-protection | `database-security-{create,read,update,delete}` | `block`, `allow` |
+
+## Go Module Import
+
+```
+go get github.com/cdot65/prisma-airs-go@v0.2.1
+```

--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.1.0"
+	Version   = "0.2.1"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+## v0.2.1
+
+- **fix**: `ForceDelete` no longer errors when the API returns non-JSON on success — `DoMgmtRequest` tolerates non-JSON 2xx responses
+- **docs**: add `docs/examples/profile-crud.md` with full end-to-end CRUD walkthrough and real API responses
+- **docs**: add 7 missing Red Team methods to `docs/services/red-team-api.md`
+- **docs**: document ForceDelete non-JSON response behavior
+
+## v0.2.0
+
+- **feat**: `Profiles.GetByID` — client-side filter over List (no dedicated API endpoint)
+- **feat**: `Profiles.GetByName` — returns highest revision when multiple revisions share the same name
+- **feat**: `ProfileAction` and `ToxicContentAction` typed enums for security profile actions
+- **docs**: full documentation alignment with current codebase
+
 ## v0.1.1
 
 - **Red Team targets**: align all target models with OpenAPI spec (`TargetCreateRequest`, `TargetUpdateRequest`, `TargetContextUpdate`, `TargetProfileResponse`, `TargetListItem`)

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,7 @@ const (
 ### Constants
 
 ```go
-const Version = "0.1.0"
+const Version = "0.2.1"
 
 // Content limits
 const (


### PR DESCRIPTION
## Summary
- Bump `aisec.Version` from `0.1.0` to `0.2.1`
- Add v0.2.0 and v0.2.1 release notes to `docs/about/release-notes.md`
- Update version in `docs/reference/api-reference.md`
- Add `TERRAFORM_PROVIDER_NOTES.md` documenting SDK changes relevant to the Terraform provider (ForceDelete fix, GetByID, GetByName, typed enums, valid protection names)

## Test plan
- [x] `make check` passes
- [ ] CI passes