### PR TITLE
chore: v0.3.0 release — docs, examples, version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,23 @@ if err != nil {
 
 Error types: `ServerSideError`, `ClientSideError`, `UserRequestPayloadError`, `MissingVariableError`, `AISecSDKInternalError`, `OAuthError`.
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [Runtime Scanning](https://cdot65.github.io/prisma-airs-go/examples/runtime-scanning/) | SyncScan, AsyncScan, query results, tool event scanning, code scanning |
+| [Security Profile CRUD](https://cdot65.github.io/prisma-airs-go/examples/profile-crud/) | Create, List, GetByID, GetByName, Update, ForceDelete profiles |
+| [Custom Topics CRUD](https://cdot65.github.io/prisma-airs-go/examples/topic-crud/) | Topic lifecycle + integration with profile topic-guardrails |
+| [Red Team Scanning](https://cdot65.github.io/prisma-airs-go/examples/red-team-scanning/) | Target create, launch scan, reports, attacks, remediation |
+| [API Key Rotation](https://cdot65.github.io/prisma-airs-go/examples/api-key-rotation/) | List, identify expiring, regenerate API keys |
+
+Runnable examples in [`examples/`](examples/):
+
+```bash
+go run ./examples/basic-scan/      # requires PANW_AI_SEC_API_KEY
+go run ./examples/profile-crud/    # requires PANW_MGMT_* env vars
+```
+
 ## Documentation
 
 Full documentation at **[cdot65.github.io/prisma-airs-go](https://cdot65.github.io/prisma-airs-go/)** — includes API reference, service guides, OAuth lifecycle docs, and examples.

--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.2.1"
+	Version   = "0.3.0"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.3.0
+
+- **docs**: comprehensive runtime scanning examples — SyncScan, AsyncScan, QueryByScanIDs, QueryByReportIDs, tool event scanning, code scanning
+- **docs**: full custom topics CRUD examples with profile topic-guardrails integration
+- **docs**: end-to-end red team scanning workflow — target create, launch scan, reports, attacks, remediation, custom attacks
+- **docs**: replace stub `examples/basic-scan/main.go` with working 5-step example
+- **docs**: add Examples section to README with links to all example pages
+- **docs**: fix stale User-Agent version string in scan-api.md
+- **chore**: bump SDK version to 0.3.0
+
 ## v0.2.1
 
 - **fix**: `ForceDelete` no longer errors when the API returns non-JSON on success — `DoMgmtRequest` tolerates non-JSON 2xx responses

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,7 @@ const (
 ### Constants
 
 ```go
-const Version = "0.2.1"
+const Version = "0.3.0"
 
 // Content limits
 const (

--- a/docs/services/scan-api.md
+++ b/docs/services/scan-api.md
@@ -132,7 +132,7 @@ if err != nil {
 
 - **Retries:** Up to 5 retries with exponential backoff and full jitter
 - **Retryable status codes:** 500, 502, 503, 504
-- **User-Agent:** `PAN-AIRS/0.1.0-go-sdk`
+- **User-Agent:** `PAN-AIRS/{version}-go-sdk`
 
 ## Response Types
 


### PR DESCRIPTION
## Summary
- Comprehensive example documentation: runtime scanning, topics CRUD, red team workflows
- Working `examples/basic-scan/main.go` replacing stub
- README Examples section with links to all doc pages
- Fix stale User-Agent version in scan-api.md
- Bump SDK version to `0.3.0`
- Release notes for v0.3.0

Closes #74

## Test plan
- [x] `make check` passes (fmt, vet, lint, test)
- [x] All example code compiles (`go build ./...`)
- [x] Docs accuracy verified against codebase