### PR TITLE
fix(management): customer apps List endpoint + model alignment

### DIFF
--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -137,7 +137,7 @@ const (
 	MgmtDeploymentProfilesPath = "/v1/mgmt/deploymentprofiles"
 	MgmtScanLogsPath           = "/v1/mgmt/scanlogs"
 	MgmtCustomerAppPath        = "/v1/mgmt/customerapp"
-	MgmtCustomerAppsTsgPath    = "/v1/mgmt/customerapp/tsg"
+	MgmtCustomerAppsPath       = "/v1/mgmt/customerapps"
 	MgmtOAuthInvalidatePath    = "/v1/mgmt/oauth/invalidateToken"
 	MgmtOAuthTokenPath         = "/v1/mgmt/oauth/client_credential/accesstoken"
 )

--- a/aisec/management/client.go
+++ b/aisec/management/client.go
@@ -285,19 +285,9 @@ type CustomerAppsClient struct {
 	tsgID  string
 }
 
-func (c *CustomerAppsClient) Create(ctx context.Context, req CreateAppRequest) (*CustomerApp, error) {
-	resp, err := internal.DoMgmtRequest[CustomerApp](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodPost, Path: aisec.MgmtCustomerAppPath, Body: req,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &resp.Data, nil
-}
-
 func (c *CustomerAppsClient) List(ctx context.Context, opts ListOpts) (*CustomerAppListResponse, error) {
 	resp, err := internal.DoMgmtRequest[CustomerAppListResponse](ctx, c.svcCfg, internal.MgmtRequestOptions{
-		Method: http.MethodGet, Path: aisec.MgmtCustomerAppsTsgPath + "/" + c.tsgID, Params: buildListParams(opts),
+		Method: http.MethodGet, Path: aisec.MgmtCustomerAppsPath, Params: buildListParams(opts),
 	})
 	if err != nil {
 		return nil, err

--- a/aisec/management/client_test.go
+++ b/aisec/management/client_test.go
@@ -230,7 +230,7 @@ func TestApiKeys_Create(t *testing.T) {
 	}
 }
 
-func TestCustomerApps_CRUD(t *testing.T) {
+func TestCustomerApps_GetAndUpdate(t *testing.T) {
 	tokenSrv, apiSrv := newTestMgmtServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(CustomerApp{CustomerAppID: "a-1", AppName: "test-app"})
 	})
@@ -238,14 +238,6 @@ func TestCustomerApps_CRUD(t *testing.T) {
 	defer apiSrv.Close()
 
 	client := newTestClient(t, tokenSrv.URL, apiSrv.URL)
-
-	app, err := client.CustomerApps.Create(context.Background(), CreateAppRequest{AppName: "test-app", TsgID: "123", CloudProvider: "aws", Environment: "prod"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if app.CustomerAppID != "a-1" {
-		t.Errorf("CustomerAppID = %q", app.CustomerAppID)
-	}
 
 	got, err := client.CustomerApps.Get(context.Background(), "test-app")
 	if err != nil {
@@ -800,8 +792,15 @@ func TestCustomerApps_List(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("method = %s", r.Method)
 		}
+		// Spec endpoint is /v1/mgmt/customerapps (no TSG in path).
+		if strings.Contains(r.URL.Path, "/tsg/") {
+			t.Errorf("path should not contain /tsg/: %s", r.URL.Path)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/customerapps") {
+			t.Errorf("path should end with /customerapps: %s", r.URL.Path)
+		}
 		_ = json.NewEncoder(w).Encode(CustomerAppListResponse{
-			Items: []CustomerApp{{CustomerAppID: "a-1"}},
+			Items: []CustomerApp{{CustomerAppID: "a-1", AgentApp: true, AiSecProfileName: "prof-1"}},
 		})
 	})
 	defer tokenSrv.Close()
@@ -814,6 +813,12 @@ func TestCustomerApps_List(t *testing.T) {
 	}
 	if len(resp.Items) != 1 {
 		t.Errorf("items = %d", len(resp.Items))
+	}
+	if !resp.Items[0].AgentApp {
+		t.Error("AgentApp should be true")
+	}
+	if resp.Items[0].AiSecProfileName != "prof-1" {
+		t.Errorf("AiSecProfileName = %q", resp.Items[0].AiSecProfileName)
 	}
 }
 
@@ -1428,9 +1433,62 @@ func TestTopicArrayConfig_ActionEnum(t *testing.T) {
 	}
 }
 
-func TestCustomerAppWithKeyInfo_JSON(t *testing.T) {
+func TestCustomerApp_AllFields_JSON(t *testing.T) {
+	j := `{
+		"customer_appId": "c8c8822e-817b-447b-b321-3efb8e3f5528",
+		"app_name": "insomnia-client",
+		"tsg_id": "1533764915",
+		"model_name": "default",
+		"cloud_provider": "other",
+		"environment": "dev",
+		"agent_app": true,
+		"ai_agent_framework": "AWS_Agent_Builder",
+		"ai_sec_profile_name": "AI-Firewall-High-Security-Profile",
+		"api_keys_dp_info": [
+			{"api_key_name": "insomnia-api-key", "auth_code": "D6970665", "dp_name": "cdot65-ai-runtime"}
+		]
+	}`
+	var app CustomerApp
+	if err := json.Unmarshal([]byte(j), &app); err != nil {
+		t.Fatal(err)
+	}
+	if !app.AgentApp {
+		t.Error("AgentApp should be true")
+	}
+	if app.AiSecProfileName != "AI-Firewall-High-Security-Profile" {
+		t.Errorf("AiSecProfileName = %q", app.AiSecProfileName)
+	}
+	if len(app.ApiKeysDPInfo) != 1 {
+		t.Fatalf("ApiKeysDPInfo len = %d", len(app.ApiKeysDPInfo))
+	}
+	if app.ApiKeysDPInfo[0].ApiKeyName != "insomnia-api-key" {
+		t.Errorf("ApiKeyName = %q", app.ApiKeysDPInfo[0].ApiKeyName)
+	}
+	if app.ApiKeysDPInfo[0].AuthCode != "D6970665" {
+		t.Errorf("AuthCode = %q", app.ApiKeysDPInfo[0].AuthCode)
+	}
+
+	// Round-trip: verify new fields serialize correctly.
+	data, err := json.Marshal(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	_ = json.Unmarshal(data, &raw)
+	if _, ok := raw["agent_app"]; !ok {
+		t.Error("missing agent_app in JSON")
+	}
+	if _, ok := raw["ai_sec_profile_name"]; !ok {
+		t.Error("missing ai_sec_profile_name in JSON")
+	}
+	if _, ok := raw["api_keys_dp_info"]; !ok {
+		t.Error("missing api_keys_dp_info in JSON")
+	}
+}
+
+func TestCustomerApp_ApiKeysDPInfo_JSON(t *testing.T) {
 	j := `{"customer_appId":"a1","app_name":"test","tsg_id":"t1","api_keys_dp_info":[{"api_key_name":"k1","dp_name":"dp1","auth_code":"ac1"}]}`
-	var app CustomerAppWithKeyInfo
+	var app CustomerApp
 	if err := json.Unmarshal([]byte(j), &app); err != nil {
 		t.Fatal(err)
 	}

--- a/aisec/management/models.go
+++ b/aisec/management/models.go
@@ -273,30 +273,25 @@ type ApiKeyDeleteResponse struct {
 
 // CustomerApp represents a customer application.
 type CustomerApp struct {
-	CustomerAppID    string `json:"customer_appId,omitempty"`
-	AppName          string `json:"app_name,omitempty"`
-	TsgID            string `json:"tsg_id,omitempty"`
-	ModelName        string `json:"model_name,omitempty"`
-	CloudProvider    string `json:"cloud_provider,omitempty"`
-	Environment      string `json:"environment,omitempty"`
-	Status           string `json:"status,omitempty"`
-	CreatedBy        string `json:"created_by,omitempty"`
-	UpdatedBy        string `json:"updated_by,omitempty"`
-	AiAgentFramework string `json:"ai_agent_framework,omitempty"`
+	CustomerAppID    string         `json:"customer_appId,omitempty"`
+	AppName          string         `json:"app_name,omitempty"`
+	TsgID            string         `json:"tsg_id,omitempty"`
+	ModelName        string         `json:"model_name,omitempty"`
+	CloudProvider    string         `json:"cloud_provider,omitempty"`
+	Environment      string         `json:"environment,omitempty"`
+	Status           string         `json:"status,omitempty"`
+	CreatedBy        string         `json:"created_by,omitempty"`
+	UpdatedBy        string         `json:"updated_by,omitempty"`
+	AgentApp         bool           `json:"agent_app,omitempty"`
+	AiAgentFramework string         `json:"ai_agent_framework,omitempty"`
+	AiSecProfileName string         `json:"ai_sec_profile_name,omitempty"`
+	ApiKeysDPInfo    []APIKeyDPInfo `json:"api_keys_dp_info,omitempty"`
 }
 
 // CustomerAppListResponse is the list response for customer apps.
 type CustomerAppListResponse struct {
 	Items      []CustomerApp `json:"customer_apps"`
 	NextOffset int           `json:"next_offset,omitempty"`
-}
-
-// CreateAppRequest is the request to create a customer app.
-type CreateAppRequest struct {
-	AppName       string `json:"app_name"`
-	TsgID         string `json:"tsg_id"`
-	CloudProvider string `json:"cloud_provider"`
-	Environment   string `json:"environment"`
 }
 
 // UpdateAppRequest is the request to update a customer app.
@@ -481,21 +476,6 @@ type APIKeyDPInfo struct {
 	ApiKeyName string `json:"api_key_name"`
 	DpName     string `json:"dp_name"`
 	AuthCode   string `json:"auth_code"`
-}
-
-// CustomerAppWithKeyInfo extends CustomerApp with associated API key/DP info.
-type CustomerAppWithKeyInfo struct {
-	CustomerAppID    string         `json:"customer_appId,omitempty"`
-	AppName          string         `json:"app_name,omitempty"`
-	TsgID            string         `json:"tsg_id,omitempty"`
-	ModelName        string         `json:"model_name,omitempty"`
-	CloudProvider    string         `json:"cloud_provider,omitempty"`
-	Environment      string         `json:"environment,omitempty"`
-	Status           string         `json:"status,omitempty"`
-	CreatedBy        string         `json:"created_by,omitempty"`
-	UpdatedBy        string         `json:"updated_by,omitempty"`
-	AiAgentFramework string         `json:"ai_agent_framework,omitempty"`
-	ApiKeysDPInfo    []APIKeyDPInfo `json:"api_keys_dp_info,omitempty"`
 }
 
 // InvalidateTokenResponse is the response from invalidating a token.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -215,7 +215,6 @@ func (c *ApiKeysClient) Regenerate(ctx context.Context, keyID string, req Regene
 ### CustomerAppsClient
 
 ```go
-func (c *CustomerAppsClient) Create(ctx context.Context, req CreateAppRequest) (*CustomerApp, error)
 func (c *CustomerAppsClient) List(ctx context.Context, opts ListOpts) (*CustomerAppListResponse, error)
 func (c *CustomerAppsClient) Get(ctx context.Context, appName string) (*CustomerApp, error)
 func (c *CustomerAppsClient) Update(ctx context.Context, appID string, req UpdateAppRequest) (*CustomerApp, error)

--- a/docs/services/management-api.md
+++ b/docs/services/management-api.md
@@ -91,7 +91,6 @@ newKey, err := client.ApiKeys.Regenerate(ctx, "key-id", management.RegenerateKey
 ### CustomerApps — Customer Application Management
 
 ```go
-app, err := client.CustomerApps.Create(ctx, management.CreateAppRequest{...})
 apps, err := client.CustomerApps.List(ctx, management.ListOpts{})
 app, err := client.CustomerApps.Get(ctx, "app-name")
 updated, err := client.CustomerApps.Update(ctx, "app-id", management.UpdateAppRequest{...})


### PR DESCRIPTION
## Summary
- Fix List URL from `/v1/mgmt/customerapp/tsg/{id}` to `/v1/mgmt/customerapps` (per OpenAPI spec) — resolves timeout
- Add missing fields to `CustomerApp`: `AgentApp` (bool), `AiSecProfileName` (string), `ApiKeysDPInfo` ([]APIKeyDPInfo)
- Remove `Create` method — not in OpenAPI spec
- Remove redundant `CustomerAppWithKeyInfo` type (now covered by `CustomerApp`)

Closes #77

## Test plan
- [x] `make check` passes
- [x] List endpoint test asserts correct path (`/customerapps`, no `/tsg/`)
- [x] New fields deserialize correctly from real API response shape
- [x] JSON round-trip test for all new fields