### PR TITLE
chore: v0.3.1 release — customer apps fix + docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go 1.22+](https://img.shields.io/badge/go-%3E%3D1.22-00ADD8)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Go SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all three service domains: **AI Runtime Security**, **AI Red Teaming**, and **Model Security**.
+Go SDK for Palo Alto Networks **Prisma AIRS** — covering the full lifecycle from configuration management to operational scanning across all four service domains: **AI Runtime Security**, **Management**, **Model Security**, and **AI Red Teaming**.
 
 ## Installation
 

--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.3.0"
+	Version   = "0.3.1"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.3.1
+
+- **fix**: customer apps `List` endpoint changed from `/v1/mgmt/customerapp/tsg/{id}` to `/v1/mgmt/customerapps` per OpenAPI spec — resolves timeout
+- **fix**: add missing `AgentApp`, `AiSecProfileName`, `ApiKeysDPInfo` fields to `CustomerApp` struct
+- **breaking**: remove `Create` method from `CustomerAppsClient` (not in OpenAPI spec)
+- **breaking**: remove redundant `CustomerAppWithKeyInfo` type (fields merged into `CustomerApp`)
+- **docs**: add `CustomerApp`, `APIKeyDPInfo` type definitions to API reference
+- **docs**: fix README service domain count
+
 ## v0.3.0
 
 - **docs**: comprehensive runtime scanning examples — SyncScan, AsyncScan, QueryByScanIDs, QueryByReportIDs, tool event scanning, code scanning

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,7 @@ const (
 ### Constants
 
 ```go
-const Version = "0.3.0"
+const Version = "0.3.1"
 
 // Content limits
 const (
@@ -219,6 +219,44 @@ func (c *CustomerAppsClient) List(ctx context.Context, opts ListOpts) (*Customer
 func (c *CustomerAppsClient) Get(ctx context.Context, appName string) (*CustomerApp, error)
 func (c *CustomerAppsClient) Update(ctx context.Context, appID string, req UpdateAppRequest) (*CustomerApp, error)
 func (c *CustomerAppsClient) Delete(ctx context.Context, appName string, updatedBy string) (*DeleteAppResponse, error)
+```
+
+### CustomerApp Types
+
+```go
+type CustomerApp struct {
+    CustomerAppID    string         `json:"customer_appId,omitempty"`
+    AppName          string         `json:"app_name,omitempty"`
+    TsgID            string         `json:"tsg_id,omitempty"`
+    ModelName        string         `json:"model_name,omitempty"`
+    CloudProvider    string         `json:"cloud_provider,omitempty"`
+    Environment      string         `json:"environment,omitempty"`
+    Status           string         `json:"status,omitempty"`
+    CreatedBy        string         `json:"created_by,omitempty"`
+    UpdatedBy        string         `json:"updated_by,omitempty"`
+    AgentApp         bool           `json:"agent_app,omitempty"`
+    AiAgentFramework string         `json:"ai_agent_framework,omitempty"`
+    AiSecProfileName string         `json:"ai_sec_profile_name,omitempty"`
+    ApiKeysDPInfo    []APIKeyDPInfo `json:"api_keys_dp_info,omitempty"`
+}
+
+type CustomerAppListResponse struct {
+    Items      []CustomerApp `json:"customer_apps"`
+    NextOffset int           `json:"next_offset,omitempty"`
+}
+
+type UpdateAppRequest struct {
+    AppName       string `json:"app_name,omitempty"`
+    ModelName     string `json:"model_name,omitempty"`
+    CloudProvider string `json:"cloud_provider,omitempty"`
+    Environment   string `json:"environment,omitempty"`
+}
+
+type APIKeyDPInfo struct {
+    ApiKeyName string `json:"api_key_name"`
+    DpName     string `json:"dp_name"`
+    AuthCode   string `json:"auth_code"`
+}
 ```
 
 ### ScanLogsClient


### PR DESCRIPTION
## Summary
- Bump SDK version to `0.3.1`
- Add `CustomerApp`, `APIKeyDPInfo` type definitions to API reference
- Fix README service domain count (three → four)
- v0.3.1 release notes

## Test plan
- [x] `make check` passes