### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.3.1"
+	Version   = "0.4.0"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## v0.4.0
+
+- **breaking**: consolidate `aisec/management` and `aisec/scan` into unified `aisec/runtime` package — all import paths change
+- **feat**: add `DefaultURLCategory`, `UrlDetectedAction`, `MaliciousCodeProtection` fields to `AppProtectionConfig`
+- **feat**: add `DatabaseSecurity` field to `DataProtectionConfig` with `DatabaseSecurityConfig` type
+- **refactor**: package structure now mirrors functional domains: `runtime`, `modelsecurity`, `redteam`
+- **docs**: rename `management-api.md` to `runtime-api.md`, update all documentation
+
+### Migration
+
+```diff
+- import "github.com/cdot65/prisma-airs-go/aisec/management"
+- import "github.com/cdot65/prisma-airs-go/aisec/scan"
++ import "github.com/cdot65/prisma-airs-go/aisec/runtime"
+
+- client, err := management.NewClient(management.Opts{...})
++ client, err := runtime.NewClient(runtime.Opts{...})
+
+- scanner := scan.NewScanner(cfg)
++ scanner := runtime.NewScanner(cfg)
+```
+
 ## v0.3.1
 
 - **fix**: customer apps `List` endpoint changed from `/v1/mgmt/customerapp/tsg/{id}` to `/v1/mgmt/customerapps` per OpenAPI spec — resolves timeout

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,7 @@ const (
 ### Constants
 
 ```go
-const Version = "0.3.1"
+const Version = "0.4.0"
 
 // Content limits
 const (

--- a/sdk-update-001.md
+++ b/sdk-update-001.md
@@ -1,6 +1,6 @@
 # SDK Update 001: Missing Management Model Fields
 
-**SDK:** `prisma-airs-go` v0.3.1 → v0.3.2 (pending version bump)
+**SDK:** `prisma-airs-go` v0.3.1 → v0.4.0
 **PRs:** #82, #83
 **Package:** `github.com/cdot65/prisma-airs-go/aisec/runtime`
 **File:** `aisec/runtime/models.go`


### PR DESCRIPTION
## Summary
- Bump SDK version from 0.3.1 to 0.4.0
- Add v0.4.0 release notes with migration guide
- Update version constant in `aisec/constants.go` and api-reference docs

## Changes
- `aisec/constants.go`: Version = "0.4.0"
- `docs/about/release-notes.md`: v0.4.0 entry with breaking changes + migration guide
- `docs/reference/api-reference.md`: version string
- `sdk-update-001.md`: version reference

## Checklist
- [x] `make check` passes
- [x] Release notes include migration guide for breaking import path changes