### PR TITLE
chore: bump version to v0.4.1

### DIFF
--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.4.0"
+	Version   = "0.4.1"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v0.4.1
+
+- **fix**: remove `omitempty` from 33 plain `bool` JSON struct tags — `false` was silently dropped during marshaling, causing Terraform state drift
+
 ## v0.4.0
 
 - **breaking**: consolidate `aisec/management` and `aisec/scan` into unified `aisec/runtime` package — all import paths change

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,7 @@ const (
 ### Constants
 
 ```go
-const Version = "0.4.0"
+const Version = "0.4.1"
 
 // Content limits
 const (


### PR DESCRIPTION
## Summary
- Patch bump for bool omitempty fix (#87)
- Update version in `aisec/constants.go`, `docs/reference/api-reference.md`
- Add v0.4.1 release notes entry

Closes #0