### PR TITLE
chore: bump version to v0.5.0, update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ aisec/                      # Core package: constants, config, errors, utils
   internal/                 # Private: HTTP client, retry, OAuth client
   runtime/                  # Runtime API — Scanner (API key) + Client with 8 sub-clients (OAuth2)
   modelsecurity/            # Model Security API — 3 sub-clients, dual endpoint (OAuth2)
-  redteam/                  # Red Team API — 5 sub-clients, dual endpoint (OAuth2)
+  redteam/                  # Red Team API — 7 sub-clients, dual endpoint (OAuth2)
 docs/                       # MkDocs Material source
 .github/workflows/          # CI (lint/test), test matrix (Go 1.22-1.24), mkdocs deploy, release
 examples/                   # Usage examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ go test -v ./... -run "TestName"
 - **Runtime API — Scan** (API Key): `runtime.NewScanner(cfg)` → SyncScan, AsyncScan, QueryByScanIDs, QueryByReportIDs
 - **Runtime API — Management** (OAuth2): `runtime.NewClient(opts)` → 8 sub-clients (profiles, topics, apikeys, apps, dlp, deployment, scanlogs, oauth)
 - **Model Security API** (OAuth2): `modelsecurity.NewClient(opts)` → 3 sub-clients (scans, groups, rules) + GetPyPIAuth, dual endpoint
-- **Red Team API** (OAuth2): `redteam.NewClient(opts)` → 5 sub-clients (scans, reports, customAttackReports, targets, customAttacks) + 7 convenience methods, dual endpoint
+- **Red Team API** (OAuth2): `redteam.NewClient(opts)` → 7 sub-clients (scans, reports, customAttackReports, targets, customAttacks, eula, instances) + 10 convenience methods, dual endpoint
 
 Key packages:
 
@@ -40,7 +40,7 @@ Key packages:
 - `aisec/internal/` — `DoRequest[T]`, `DoMgmtRequest[T]`, `ExecuteWithRetry`, `OAuthClient`, `ResolveOAuthConfig`
 - `aisec/runtime/` — Scanner + Content (data plane) and Client + 8 sub-clients (management plane)
 - `aisec/modelsecurity/` — Client + 3 sub-clients, data plane / mgmt plane split
-- `aisec/redteam/` — Client + 5 sub-clients + 7 convenience methods, data plane / mgmt plane split
+- `aisec/redteam/` — Client + 7 sub-clients + 10 convenience methods, data plane / mgmt plane split
 
 **Auth:** API key (HMAC-SHA256) for scans. OAuth2 client_credentials (with token caching, proactive refresh, concurrent dedup, 401/403 auto-retry) for everything else.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ import "github.com/cdot65/prisma-airs-go/aisec/redteam"
 
 client, err := redteam.NewClient(redteam.Opts{}) // falls back to PANW_MGMT_* env vars
 
-// 5 sub-clients + 7 convenience methods
+// 7 sub-clients + 10 convenience methods
 scans, _ := client.Scans.List(ctx, redteam.ScanListOpts{Limit: 5})
 targets, _ := client.Targets.List(ctx, redteam.TargetListOpts{})
 categories, _ := client.Scans.GetCategories(ctx)

--- a/aisec/constants.go
+++ b/aisec/constants.go
@@ -2,7 +2,7 @@ package aisec
 
 // Version and user agent.
 const (
-	Version   = "0.4.1"
+	Version   = "0.5.0"
 	UserAgent = "PAN-AIRS/" + Version + "-go-sdk"
 )
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -1,5 +1,26 @@
 # Release Notes
 
+## v0.5.0
+
+- **feat**: add `EulaClient` sub-client with `GetContent`, `GetStatus`, `Accept` methods
+- **feat**: add `InstancesClient` sub-client with 7 methods — `Create`, `Get`, `Update`, `Delete`, `CreateDevice`, `UpdateDevice`, `DeleteDevice`
+- **feat**: add `ValidateAuth` method on `TargetsClient` for auth configuration validation
+- **feat**: add `GetTargetMetadata`, `GetTargetTemplates`, `GetRegistryCredentials` convenience methods
+- **feat**: add `UploadPromptsCsv` and `DownloadTemplate` methods on `CustomAttacksClient`
+- **feat**: add typed auth config structs — `HeadersAuthConfig`, `BasicAuthAuthConfig`, `OAuth2AuthConfig` with `AuthConfigType` enum
+- **feat**: add `WEBSOCKET` to `TargetConnectionType` and `ResponseMode` enums
+- **fix**: `UpdateProfile` path corrected from `/context` to `/profile`
+- **fix**: `GetPropertyValuesMultiple` changed from POST with body to GET with query param
+- **fix**: `CreatePropertyValue` path removed erroneous `/create` suffix
+- **fix**: `DashboardOverviewResponse` typed with `TotalTargets` + `TargetsByType` (was `map[string]any`)
+- **fix**: `CustomPromptSetCreateRequest`/`UpdateRequest` `Properties` field renamed to `PropertyNames []string`
+- **fix**: `CustomPromptSetVersionInfo` fully typed (was `map[string]any`)
+- **fix**: `TargetProbeRequest` metadata fields typed as `*TargetMetadata`, `*TargetBackground`, `*TargetAdditionalContext`
+- **fix**: `TargetResponse` now includes `NetworkBrokerChannelUUID`, `AuthConfigType`, `AuthConfig` fields
+- **refactor**: split `models.go` into 7 domain files (`models_enums.go`, `models_target.go`, `models_scan.go`, `models_custom_attack.go`, `models_dashboard.go`, `models_eula.go`, `models_instance.go`)
+- **chore**: update red team mgmt-plane spec to latest OpenAPI JSON
+- **docs**: update red team API docs with all new endpoints and sub-clients
+
 ## v0.4.1
 
 - **fix**: remove `omitempty` from 33 plain `bool` JSON struct tags — `false` was silently dropped during marshaling, causing Terraform state drift

--- a/docs/services/red-team-api.md
+++ b/docs/services/red-team-api.md
@@ -26,7 +26,9 @@ graph TD
     A --> D[CustomAttackReports<br/>Data Plane]
     A --> E[Targets<br/>Mgmt Plane]
     A --> F[CustomAttacks<br/>Mgmt Plane]
-    A --> G[Convenience Methods]
+    A --> G[Eula<br/>Mgmt Plane]
+    A --> H[Instances<br/>Mgmt Plane]
+    A --> I[Convenience Methods]
 ```
 
 ## Scans (Data Plane)
@@ -142,6 +144,12 @@ profile, err := client.Targets.GetProfile(ctx, "target-uuid")
 updated, err = client.Targets.UpdateProfile(ctx, "target-uuid", redteam.TargetContextUpdate{
     TargetBackground: &redteam.TargetBackground{Industry: "Healthcare"},
 })
+
+// Validate target auth configuration
+validation, err := client.Targets.ValidateAuth(ctx, redteam.TargetAuthValidationRequest{
+    AuthType:   redteam.AuthConfigTypeHeaders,
+    AuthConfig: redteam.HeadersAuthConfig{AuthHeader: map[string]string{"X-API-Key": "key"}},
+})
 ```
 
 ## Custom Attacks (Management Plane)
@@ -167,7 +175,9 @@ active, err := client.CustomAttacks.ListActivePromptSets(ctx)
 
 // Get prompt set reference and version info
 ref, err := client.CustomAttacks.GetPromptSetReference(ctx, "prompt-set-uuid")
-versionInfo, err := client.CustomAttacks.GetPromptSetVersionInfo(ctx, "prompt-set-uuid")
+versionInfo, err := client.CustomAttacks.GetPromptSetVersionInfo(ctx, "prompt-set-uuid", "")
+// With specific version:
+versionInfo, err = client.CustomAttacks.GetPromptSetVersionInfo(ctx, "prompt-set-uuid", "2")
 ```
 
 ### Prompts
@@ -195,6 +205,51 @@ multiValues, err := client.CustomAttacks.GetPropertyValuesMultiple(ctx, []string
 resp, err := client.CustomAttacks.CreatePropertyValue(ctx, redteam.PropertyValueCreateRequest{...})
 ```
 
+### CSV Upload/Download
+
+```go
+// Upload prompts from CSV
+csvFile, _ := os.Open("prompts.csv")
+resp, err := client.CustomAttacks.UploadPromptsCsv(ctx, "prompt-set-uuid", csvFile, "prompts.csv")
+
+// Download CSV template for a prompt set
+data, err := client.CustomAttacks.DownloadTemplate(ctx, "prompt-set-uuid")
+```
+
+## EULA (Management Plane)
+
+```go
+// Get EULA content
+content, err := client.Eula.GetContent(ctx)
+
+// Check EULA acceptance status
+status, err := client.Eula.GetStatus(ctx)
+
+// Accept EULA
+resp, err := client.Eula.Accept(ctx, redteam.EulaAcceptRequest{
+    EulaContent: content.Content,
+})
+```
+
+## Instances (Management Plane)
+
+```go
+// Create an instance
+inst, err := client.Instances.Create(ctx, redteam.InstanceRequest{
+    TsgID: "tsg-1", TenantID: "t-1", AppID: "app-1", Region: "us-east-1",
+})
+
+// Get, update, delete instances
+inst, err := client.Instances.Get(ctx, "tenant-id")
+updated, err := client.Instances.Update(ctx, "tenant-id", redteam.InstanceRequest{...})
+resp, err := client.Instances.Delete(ctx, "tenant-id")
+
+// Device management
+deviceResp, err := client.Instances.CreateDevice(ctx, "tenant-id", redteam.DeviceRequest{...})
+deviceResp, err = client.Instances.UpdateDevice(ctx, "tenant-id", redteam.DeviceRequest{...})
+deviceResp, err = client.Instances.DeleteDevice(ctx, "tenant-id", "SN-001,SN-002")
+```
+
 ## Convenience Methods
 
 These are available directly on the `RedTeamClient`:
@@ -218,4 +273,11 @@ sentiment, err := client.GetSentiment(ctx, "job-uuid")
 
 // Management dashboard overview
 overview, err := client.GetDashboardOverview(ctx)
+
+// Target metadata and templates
+metadata, err := client.GetTargetMetadata(ctx)
+templates, err := client.GetTargetTemplates(ctx)
+
+// Registry credentials
+creds, err := client.GetRegistryCredentials(ctx)
 ```


### PR DESCRIPTION
## Summary
- Bump SDK version from 0.4.1 to 0.5.0
- Update red team API docs with all new endpoints: EULA, Instances, auth validation, CSV upload/download, templates, registry credentials
- Update architecture diagram (5 → 7 sub-clients)
- Fix `GetPromptSetVersionInfo` signature in docs (now takes optional version param)
- Add v0.5.0 release notes
- Update sub-client counts in README, CLAUDE.md, AGENTS.md

## Test plan
- [x] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)